### PR TITLE
replace random() calls with SYS_getrandom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ C_SRCS = $(SRC_DIR)/*.c
 CXX_SRCS = $(SRC_DIR)/*.cpp
 BUILD_DIR = build
 
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+CFLAGS += -framework Security  # should really be a LDFLAGS
+endif
+
 all: library tests
 
 ## Build a release version of the library

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -10,7 +10,13 @@
 #pragma message "IsoAlloc is untested and unsupported on 32 bit platforms"
 #endif
 
+#if __linux__
 #include <byteswap.h>
+#elif __APPLE__
+#include <libkern/OSByteOrder.h>
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+#endif
 #include <errno.h>
 #include <inttypes.h>
 #include <limits.h>

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -283,9 +283,9 @@ INTERNAL_HIDDEN void write_canary(iso_alloc_zone *zone, void *p);
 INTERNAL_HIDDEN void mprotect_pages(void *p, size_t size, int32_t protection);
 INTERNAL_HIDDEN void *mmap_rw_pages(size_t size, bool populate);
 INTERNAL_HIDDEN void _iso_alloc_destroy_zone(iso_alloc_zone *zone);
-INTERNAL_HIDDEN void iso_alloc_new_root();
+INTERNAL_HIDDEN void iso_alloc_new_root(void);
 INTERNAL_HIDDEN void verify_zone(iso_alloc_zone *zone);
-INTERNAL_HIDDEN void verify_all_zones();
+INTERNAL_HIDDEN void verify_all_zones(void);
 INTERNAL_HIDDEN void insert_free_bit_slot(iso_alloc_zone *zone, int64_t bit_slot);
 INTERNAL_HIDDEN void _iso_free(void *p, bool permanent);
 INTERNAL_HIDDEN void iso_free_big_zone(iso_alloc_big_zone *big_zone, bool permanent);
@@ -294,12 +294,12 @@ INTERNAL_HIDDEN void *_iso_big_alloc(size_t size);
 INTERNAL_HIDDEN void *_iso_alloc(iso_alloc_zone *zone, size_t size);
 INTERNAL_HIDDEN void *_iso_calloc(size_t nmemb, size_t size);
 INTERNAL_HIDDEN uint64_t _iso_alloc_zone_leak_detector(iso_alloc_zone *zone);
-INTERNAL_HIDDEN uint64_t _iso_alloc_detect_leaks();
+INTERNAL_HIDDEN uint64_t _iso_alloc_detect_leaks(void);
 INTERNAL_HIDDEN uint64_t _iso_alloc_zone_mem_usage(iso_alloc_zone *zone);
-INTERNAL_HIDDEN uint64_t _iso_alloc_mem_usage();
+INTERNAL_HIDDEN uint64_t _iso_alloc_mem_usage(void);
 INTERNAL_HIDDEN size_t _iso_chunk_size(void *p);
-INTERNAL_HIDDEN void _iso_alloc_protect_root();
-INTERNAL_HIDDEN void _iso_alloc_unprotect_root();
+INTERNAL_HIDDEN void _iso_alloc_protect_root(void);
+INTERNAL_HIDDEN void _iso_alloc_unprotect_root(void);
 
 #if UNIT_TESTING
 EXTERNAL_API iso_alloc_root *_get_root();

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -27,7 +27,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
-#include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -300,6 +299,7 @@ INTERNAL_HIDDEN uint64_t _iso_alloc_mem_usage(void);
 INTERNAL_HIDDEN size_t _iso_chunk_size(void *p);
 INTERNAL_HIDDEN void _iso_alloc_protect_root(void);
 INTERNAL_HIDDEN void _iso_alloc_unprotect_root(void);
+INTERNAL_HIDDEN uint64_t rand_uint64(void);
 
 #if UNIT_TESTING
 EXTERNAL_API iso_alloc_root *_get_root();

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -48,7 +48,7 @@ INTERNAL_HIDDEN void create_canary_chunks(iso_alloc_zone *zone) {
 /* Verify the integrity of all canary chunks and the
  * canary written to all free chunks. This function
  * either aborts or returns nothing */
-INTERNAL_HIDDEN void verify_all_zones() {
+INTERNAL_HIDDEN void verify_all_zones(void) {
     for(int32_t i = 0; i < _root->zones_used; i++) {
         iso_alloc_zone *zone = &_root->zones[i];
 
@@ -228,7 +228,7 @@ INTERNAL_HIDDEN void mprotect_pages(void *p, size_t size, int32_t protection) {
     }
 }
 
-INTERNAL_HIDDEN void iso_alloc_new_root() {
+INTERNAL_HIDDEN void iso_alloc_new_root(void) {
     void *p = NULL;
 
     size_t _root_size = sizeof(iso_alloc_root) + (g_page_size * 2);
@@ -258,7 +258,7 @@ INTERNAL_HIDDEN void iso_alloc_new_root() {
     madvise(_root->guard_above, _root->system_page_size, MADV_DONTNEED);
 }
 
-INTERNAL_HIDDEN void iso_alloc_initialize() {
+INTERNAL_HIDDEN void iso_alloc_initialize(void) {
     /* Do not allow a reinitialization unless root is NULL */
     if(_root != NULL) {
         return;
@@ -292,7 +292,7 @@ INTERNAL_HIDDEN void iso_alloc_initialize() {
     _root->big_zone_canary_secret = (random() * random());
 }
 
-__attribute__((constructor(FIRST_CTOR))) void iso_alloc_ctor() {
+__attribute__((constructor(FIRST_CTOR))) void iso_alloc_ctor(void) {
     iso_alloc_initialize();
 }
 
@@ -322,7 +322,7 @@ INTERNAL_HIDDEN void _iso_alloc_destroy_zone(iso_alloc_zone *zone) {
     }
 }
 
-__attribute__((destructor(LAST_DTOR))) void iso_alloc_dtor() {
+__attribute__((destructor(LAST_DTOR))) void iso_alloc_dtor(void) {
 #if DEBUG && (LEAK_DETECTOR || MEM_USAGE)
     uint64_t mb = 0;
 
@@ -1135,12 +1135,12 @@ INTERNAL_HIDDEN void _iso_free(void *p, bool permanent) {
 }
 
 /* Disable all use of iso_alloc by protecting the _root */
-INTERNAL_HIDDEN void _iso_alloc_protect_root() {
+INTERNAL_HIDDEN void _iso_alloc_protect_root(void) {
     mprotect_pages(_root, sizeof(iso_alloc_root), PROT_NONE);
 }
 
 /* Unprotect all use of iso_alloc by allowing R/W of the _root */
-INTERNAL_HIDDEN void _iso_alloc_unprotect_root() {
+INTERNAL_HIDDEN void _iso_alloc_unprotect_root(void) {
     mprotect_pages(_root, sizeof(iso_alloc_root), PROT_READ | PROT_WRITE);
 }
 
@@ -1169,7 +1169,7 @@ INTERNAL_HIDDEN size_t _iso_chunk_size(void *p) {
 /* Some tests require getting access to IsoAlloc internals
  * that aren't supported by the API. We never want these
  * in release builds of the library */
-EXTERNAL_API iso_alloc_root *_get_root() {
+EXTERNAL_API iso_alloc_root *_get_root(void) {
     return _root;
 }
 #endif

--- a/src/iso_alloc_random.c
+++ b/src/iso_alloc_random.c
@@ -1,0 +1,28 @@
+#if __linux__
+#include <linux/random.h>
+#include <sys/syscall.h>
+#elif __APPLE__
+#include <Security/SecRandom.h>
+#else
+#error "unknown OS"
+#endif
+#include "iso_alloc_internal.h"
+
+
+INTERNAL_HIDDEN uint64_t rand_uint64(void)
+{
+   uint64_t val;
+
+   // In modern versions of glibc (>=2.25) we can call getrandom(),
+   // but older versions of glibc are still in use as of writing this.
+   // Use the raw system call as a lower common denominator.
+
+   // We give up on checking the return value. The alternative would be
+   // to crash. We prefer here to keep going with degraded randomness.
+   #if __linux__
+   (void)syscall(SYS_getrandom, &val, sizeof(val), GRND_NONBLOCK);
+   #elif __APPLE__
+   (void)SecRandomCopyBytes(kSecRandomDefault, sizeof(val), &val);
+   #endif
+   return val;
+}


### PR DESCRIPTION
The main change here just replaces `random()` calls with an entropy-supplying system call. This is notoriously non-portable so only attempting to cover modern-ish Linux and Darwin.

Validated with existing tests on Linux. Performance as per `make malloc_cmp_test` on a linux workstation isn't noticeably changed. Compiles on MacOS, but not tested further.

Fixes #1 

