### PR TITLE
Add tcmalloc to SECURITY_COMPARISON

### DIFF
--- a/SECURITY_COMPARISON.MD
+++ b/SECURITY_COMPARISON.MD
@@ -13,25 +13,25 @@ Heap allocators hide incredible complexity behind `malloc` and `free`. They must
 
 | Security Feature		    | isoalloc         | scudo 		      | mimalloc  	     | tcmalloc      | ptmalloc      | jemalloc      | musl's malloc-ng| malloc_hardened |
 |:-------------------------:|:----------------:|:----------------:|:----------------:|:-------------:|:-------------:|:-------------:|:-----------:|:---------------:|
-|Memory Isolation			|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:grey_question:|:grey_question:|:grey_question:|:x:|:heavy_check_mark:|
-|Canaries  			        |:heavy_check_mark:|:heavy_check_mark:|:x:   			 |:grey_question:|:grey_question:|:grey_question:|:heavy_check_mark:|:heavy_check_mark:|
-|Guard Pages		   	    |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:grey_question:|:grey_question:|:grey_question:|:heavy_check_mark:|:heavy_check_mark:|
+|Memory Isolation			|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:|:grey_question:|:grey_question:|:x:|:heavy_check_mark:|
+|Canaries  			        |:heavy_check_mark:|:heavy_check_mark:|:x:   			 |:x:|:grey_question:|:grey_question:|:heavy_check_mark:|:heavy_check_mark:|
+|Guard Pages		   	    |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:x:|:grey_question:|:grey_question:|:heavy_check_mark:|:heavy_check_mark:|
 |Randomized Allocations	|:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:grey_question:|:grey_question:|:grey_question:|:heavy_check_mark:|:heavy_check_mark:|
 |Pointer Obfuscation    |:heavy_check_mark:|:x:				  |:heavy_plus_sign: |:grey_question:|:grey_question:|:grey_question:|:x:|:grey_question:|
-|Double Free Detection  |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:grey_question:|:grey_question:|:grey_question:|:heavy_check_mark:|:heavy_check_mark:|
-|Chunk Alignment Check  |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:grey_question:|:grey_question:|:grey_question:|:heavy_check_mark:|:heavy_check_mark:|
-|Out Of Band Metadata   |:heavy_check_mark:|:x:				  |:x:				 |:grey_question:|:grey_question:|:grey_question:|:heavy_check_mark:|:heavy_check_mark:|
-|Permanent Frees		    |:heavy_check_mark:|:x:				  |:x:				 |:grey_question:|:grey_question:|:grey_question:|:x:|:x:|
-|Freed Chunk Sanitization   |:heavy_check_mark:|:heavy_check_mark:|:x:				 |:grey_question:|:grey_question:|:grey_question:|:x:|:heavy_check_mark:|
-|Adjacent Chunk Verification|:heavy_check_mark:|:heavy_check_mark:|:x:				 |:grey_question:|:grey_question:|:grey_question:|:x:|:x:|
-|Delayed Free    	        |:heavy_check_mark:|:heavy_check_mark:|:x:				 |:grey_question:|:grey_question:|:grey_question:|:heavy_check_mark:|:heavy_check_mark:|
-|Dangling Pointer Detection |:heavy_plus_sign: |:x:				  |:x:				 |:grey_question:|:grey_question:|:grey_question:|:x:|:x:|
-|GWP-ASAN Like Sampling     |:heavy_plus_sign: |:heavy_plus_sign: |:x:				 |:grey_question:|:grey_question:|:grey_question:|:x:|:x:|
-|Type Mismatch Detection	|:heavy_check_mark:|:heavy_check_mark:|:x:				 |:grey_question:|:grey_question:|:grey_question:|:x:|:heavy_check_mark:|
-|Size Mismatch Detection	|:heavy_check_mark:|:heavy_check_mark:|:x:				 |:grey_question:|:grey_question:|:grey_question:|:x:|:heavy_check_mark:|
-|ARM Memory Tagging			|:x:			   |:heavy_check_mark:|:x:				 |:grey_question:|:grey_question:|:grey_question:|:x:|:x:|
-|Zone/Chunk CPU Pinning		|:heavy_check_mark:|:x:				  |:x:				 |:grey_question:|:grey_question:|:grey_question:|:x:|:x:|
-|Chunk Race Error Detection |:x:			   |:heavy_check_mark:|:grey_question:   |:grey_question:|:grey_question:|:grey_question:|:grey_question:|:grey_question:|
+|Double Free Detection  |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:x:|:grey_question:|:grey_question:|:heavy_check_mark:|:heavy_check_mark:|
+|Chunk Alignment Check  |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:x:|:grey_question:|:grey_question:|:heavy_check_mark:|:heavy_check_mark:|
+|Out Of Band Metadata   |:heavy_check_mark:|:x:				  |:x:				 |:x:|:grey_question:|:grey_question:|:heavy_check_mark:|:heavy_check_mark:|
+|Permanent Frees		    |:heavy_check_mark:|:x:				  |:x:				 |:x:|:grey_question:|:grey_question:|:x:|:x:|
+|Freed Chunk Sanitization   |:heavy_check_mark:|:heavy_check_mark:|:x:				 |:x:|:grey_question:|:grey_question:|:x:|:heavy_check_mark:|
+|Adjacent Chunk Verification|:heavy_check_mark:|:heavy_check_mark:|:x:				 |:x:|:grey_question:|:grey_question:|:x:|:x:|
+|Delayed Free    	        |:heavy_check_mark:|:heavy_check_mark:|:x:				 |:x:|:grey_question:|:grey_question:|:heavy_check_mark:|:heavy_check_mark:|
+|Dangling Pointer Detection |:heavy_plus_sign: |:x:				  |:x:				 |:x:|:grey_question:|:grey_question:|:x:|:x:|
+|GWP-ASAN Like Sampling     |:heavy_plus_sign: |:heavy_plus_sign: |:x:				 |:x:|:grey_question:|:grey_question:|:x:|:x:|
+|Type Mismatch Detection	|:heavy_check_mark:|:heavy_check_mark:|:x:				 |:x:|:grey_question:|:grey_question:|:x:|:heavy_check_mark:|
+|Size Mismatch Detection	|:heavy_check_mark:|:heavy_check_mark:|:x:				 |:x:|:grey_question:|:grey_question:|:x:|:heavy_check_mark:|
+|ARM Memory Tagging			|:x:			   |:heavy_check_mark:|:x:				 |:x:|:grey_question:|:grey_question:|:x:|:x:|
+|Zone/Chunk CPU Pinning		|:heavy_check_mark:|:x:				  |:x:				 |:x:|:grey_question:|:grey_question:|:x:|:x:|
+|Chunk Race Error Detection |:x:			   |:heavy_check_mark:|:grey_question:   |:x:|:grey_question:|:grey_question:|:grey_question:|:grey_question:|
 
 **Sources**
 
@@ -48,3 +48,5 @@ Thanks to [Kostya Kortchinsky](https://twitter.com/@crypt0ad) for reviewing the 
 https://dustri.org/b/security-features-of-musl.html
 
 https://github.com/GrapheneOS/hardened_malloc#security-properties
+
+https://downloads.immunityinc.com/infiltrate-archives/webkit_heap.pdf


### PR DESCRIPTION
This analysis was based on https://github.com/gperftools/gperftools
and not on https://github.com/google/tcmalloc