### PR TITLE
Add support for no zero sized allocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,9 @@ NAMED_MAPPINGS = -DNAMED_MAPPINGS=0
 ## Abort when the allocator cannot return a valid chunk
 ABORT_ON_NULL = -DABORT_ON_NULL=0
 
+## Enable protection against misusing 0 sized allocations
+NO_ZERO_ALLOCATIONS = -DNO_ZERO_ALLOCATIONS=1
+
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
 OS_FLAGS = -framework Security
@@ -143,7 +146,7 @@ COMMON_CFLAGS = -Wall -Iinclude/ $(THREAD_SUPPORT) $(PRE_POPULATE_PAGES) $(START
 BUILD_ERROR_FLAGS = -Werror -pedantic -Wno-pointer-arith -Wno-gnu-zero-variadic-macro-arguments -Wno-format-pedantic
 CFLAGS = $(COMMON_CFLAGS) $(SECURITY_FLAGS) $(BUILD_ERROR_FLAGS) $(HOOKS) $(HEAP_PROFILER) -fvisibility=hidden \
 	-std=c11 $(SANITIZER_SUPPORT) $(ALLOC_SANITY) $(UNINIT_READ_SANITY) $(CPU_PIN) $(EXPERIMENTAL) $(UAF_PTR_PAGE) \
-	$(VERIFY_BIT_SLOT_CACHE) $(NAMED_MAPPINGS) $(ABORT_ON_NULL)
+	$(VERIFY_BIT_SLOT_CACHE) $(NAMED_MAPPINGS) $(ABORT_ON_NULL) $(NO_ZERO_ALLOCATIONS)
 CXXFLAGS = $(COMMON_CFLAGS) -DCPP_SUPPORT=1 -std=c++17 $(SANITIZER_SUPPORT) $(HOOKS)
 EXE_CFLAGS = -fPIE
 GDB_FLAGS = -g -ggdb3 -fno-omit-frame-pointer
@@ -225,6 +228,7 @@ tests: clean library_debug_unit_tests
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) tests/wild_free.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/wild_free $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) tests/unaligned_free.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/unaligned_free $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) tests/incorrect_chunk_size_multiple.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/incorrect_chunk_size_multiple $(LDFLAGS)
+	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) tests/zero_alloc.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/zero_alloc $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) tests/uninit_read.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/uninit_read $(LDFLAGS)
 	utils/run_tests.sh
 

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -475,6 +475,10 @@ typedef struct {
     size_t zones_size;
 } __attribute__((aligned(sizeof(int64_t)))) iso_alloc_root;
 
+#if NO_ZERO_ALLOCATIONS
+void *_zero_alloc_page;
+#endif
+
 #if UAF_PTR_PAGE
 #define UAF_PTR_PAGE_ODDS 1000000
 #define UAF_PTR_PAGE_ADDR 0xFF41414142434445
@@ -543,6 +547,7 @@ INTERNAL_HIDDEN void _iso_alloc_unprotect_root(void);
 INTERNAL_HIDDEN void _unmap_zone(iso_alloc_zone *zone);
 INTERNAL_HIDDEN void *create_guard_page(void *p);
 INTERNAL_HIDDEN void *mmap_rw_pages(size_t size, bool populate, const char *name);
+INTERNAL_HIDDEN void *mmap_pages(size_t size, bool populate, const char *name, int32_t prot);
 INTERNAL_HIDDEN void *_iso_big_alloc(size_t size);
 INTERNAL_HIDDEN void *_iso_alloc(iso_alloc_zone *zone, size_t size);
 INTERNAL_HIDDEN void *_iso_alloc_bitslot_from_zone(bit_slot_t bitslot, iso_alloc_zone *zone);

--- a/utils/run_tests.sh
+++ b/utils/run_tests.sh
@@ -31,7 +31,7 @@ done
 
 fail_tests=("double_free" "big_double_free" "heap_overflow" "heap_underflow"
             "leaks_test" "wild_free" "unaligned_free" "incorrect_chunk_size_multiple"
-            "big_canary_test")
+            "big_canary_test" "zero_alloc")
 
 for t in "${fail_tests[@]}"; do
     echo -n "Running $t test"


### PR DESCRIPTION
This adds support for hardening against zero sized allocations. A zero sized allocation should never be used so when this is enabled (by default) we always return a pointer to a page mapped `PROT_NONE`.