### PR TITLE
Add a github action to run the testsuite with clang

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -1,0 +1,10 @@
+name: testsuite
+on: [push, pull_request]
+jobs:
+  testsuite-clang:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt install clang
+      - run: make tests
+


### PR DESCRIPTION
This should close #22.

I had to remove references to the `zero_alloc.c` file, since it was apparently forgotten in a previous commit.