### PR TITLE
Fix _zero_alloc_page

### DIFF
--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -476,7 +476,7 @@ typedef struct {
 } __attribute__((aligned(sizeof(int64_t)))) iso_alloc_root;
 
 #if NO_ZERO_ALLOCATIONS
-void *_zero_alloc_page;
+extern void *_zero_alloc_page;
 #endif
 
 #if UAF_PTR_PAGE

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -12,6 +12,10 @@ uint32_t g_page_size;
 uint32_t _default_zone_count;
 iso_alloc_root *_root;
 
+#if NO_ZERO_ALLOCATIONS
+void *_zero_alloc_page;
+#endif
+
 /* Select a random number of chunks to be canaries. These
  * can be verified anytime by calling check_canary()
  * or check_canary_no_abort() */


### PR DESCRIPTION
This makes `_zero_alloc_page` extern which should fix some issues with older versions of clang 