### PR TITLE
Fix compilation on g++

### DIFF
--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -56,7 +56,12 @@
 
 #if THREAD_SUPPORT
 #include <pthread.h>
+#ifdef __cplusplus
+#include <atomic>
+using namespace std;
+#else
 #include <stdatomic.h>
+#endif
 #endif
 
 #if __linux__ || __ANDROID__


### PR DESCRIPTION
stdatomic.h can't be compiled in C++, clang is smart and does some back magic behind our back.

The following bug report in the glibc has been closed as WONTFIX:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60932

It suggests to use the following code:

 ```
 #ifdef __cplusplus
 #include <atomic>
 using namespace std;
 #else
 #include <stdatomic.h>
 #endif
 ```

which seems to be solving the problem.

This should fix #43