### PR TITLE
Set the pointer passed to free() to NULL

### DIFF
--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -1567,8 +1567,8 @@ INTERNAL_HIDDEN void _iso_free(void *p, bool permanent) {
         }
 
         iso_free_big_zone(big_zone, permanent);
-        return;
     }
+    p = NULL;
 }
 
 /* Disable all use of iso_alloc by protecting the _root */


### PR DESCRIPTION
This is permitted by the spec
( https://man7.org/linux/man-pages/man3/free.3p.html ),
and makes sure that dereferencing the pointer will
result in a crash.