### PR TITLE
add support for the zone lookup table and next_sz list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ malloc_cmp_test: clean
 	$(CC) $(CFLAGS) $(OPTIMIZE) $(EXE_CFLAGS) $(OS_FLAGS) -DMALLOC_PERF_TEST $(ISO_ALLOC_PRINTF_SRC) tests/tests.c -o $(BUILD_DIR)/malloc_tests
 	echo "Running IsoAlloc Performance Test"
 	build/tests
-	echo "Running glibc malloc Performance Test"
+	echo "Running system malloc Performance Test"
 	build/malloc_tests
 
 ## C++ Support - Build a debug version of the unit test

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -80,16 +80,31 @@ The same test run on an AWS t2.xlarge Ubuntu 20.04 instance with 4 `Intel(R) Xeo
 ```
 Running IsoAlloc Performance Test
 
-iso_alloc/iso_free 1441616 tests completed in 0.418426 seconds
-iso_calloc/iso_free 1441616 tests completed in 0.578068 seconds
-iso_realloc/iso_free 1441616 tests completed in 0.681393 seconds
+iso_alloc/iso_free 1441616 tests completed in 0.147336 seconds
+iso_calloc/iso_free 1441616 tests completed in 0.161482 seconds
+iso_realloc/iso_free 1441616 tests completed in 0.244981 seconds
 
 Running glibc malloc Performance Test
 
-malloc/free 1441616 tests completed in 0.352161 seconds
-calloc/free 1441616 tests completed in 0.562425 seconds
-realloc/free 1441616 tests completed in 0.590622 seconds
+malloc/free 1441616 tests completed in 0.182437 seconds
+calloc/free 1441616 tests completed in 0.246065 seconds
+realloc/free 1441616 tests completed in 0.332292 seconds
+```
 
+Here is the same test as above on Mac OS 11.6
+
+```
+Running IsoAlloc Performance Test
+
+iso_alloc/iso_free 1441616 tests completed in 0.124150 seconds
+iso_calloc/iso_free 1441616 tests completed in 0.182955 seconds
+iso_realloc/iso_free 1441616 tests completed in 0.275084 seconds
+
+Running system malloc Performance Test
+
+malloc/free 1441616 tests completed in 0.090845 seconds
+calloc/free 1441616 tests completed in 0.200397 seconds
+realloc/free 1441616 tests completed in 0.254574 seconds
 ```
 
 This same test can be used with the `perf` utility to measure basic stats like page faults and CPU utilization using both heap implementations. The output below is on the same AWS t2.xlarge instance as above.
@@ -163,10 +178,10 @@ cache-thrashN mimalloc 00.36 3356 1.44 0.00 0 229
 cache-thrashN tcmalloc 01.87 6880 7.42 0.00 0 1138
 cache-thrashN jemalloc 00.37 3760 1.46 0.00 0 296
 
-redis isoalloc 9.335 71048 4.35 0.36 0 19326 ops/sec: 214227.92
-redis mimalloc 4.611 28932 2.13 0.20 4 6657 ops/sec: 433692.97
-redis tcmalloc 5.055 37088 2.37 0.19 3 8444 ops/sec: 395588.59
-redis jemalloc 5.150 30964 2.42 0.19 5 7024 ops/sec: 388279.50
+redis isoalloc 8.669 76240 4.07 0.30 1 21473 ops/sec: 230702.66, relative time: 8.669s
+redis mimalloc 4.555 28968 2.13 0.17 4 6655 ops/sec: 439023.69, relative time: 4.555s
+redis tcmalloc 4.715 37120 2.21 0.17 3 8446 ops/sec: 424108.56, relative time: 4.715s
+redis jemalloc 5.125 30836 2.41 0.17 0 7034 ops/sec: 390174.03, relative time: 5.125s
 ```
 
 IsoAlloc isn't quite ready for performance sensitive server workloads but it's more than fast enough for client side mobile/desktop applications with risky C/C++ attack surface.

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -268,8 +268,8 @@ using namespace std;
  * create. This is a completely arbitrary number but
  * it does correspond to the size of the _root.zones
  * array that lives in global memory. Currently the
- * iso_alloc_zone structure is roughly 1088 bytes so
- * this allocates 8912896 bytes (~8.5 MB) for _root */
+ * iso_alloc_zone structure is roughly 1090 bytes so
+ * this allocates 8929280 bytes (~8.9 MB) for _root */
 #define MAX_ZONES 8192
 
 /* Each user allocation zone we make is 4mb in size.
@@ -295,6 +295,8 @@ using namespace std;
 #define BIG_ZONE_META_DATA_PAGE_COUNT 3
 #define BIG_ZONE_USER_PAGE_COUNT 2
 #define BIG_ZONE_USER_PAGE_COUNT_SHIFT 1
+
+#define ZONE_LOOKUP_TABLE_SZ ((SMALL_SZ_MAX+1) * sizeof(uint16_t))
 
 /* We allocate zones at startup for common sizes.
  * Each of these default zones is ZONE_USER_SIZE bytes
@@ -414,6 +416,7 @@ static uint64_t default_zones[] = {ZONE_512, ZONE_512, ZONE_512, ZONE_1024};
 
 typedef uint64_t bit_slot_t;
 typedef int64_t bitmap_index_t;
+typedef uint16_t zone_lookup_table_t;
 
 typedef struct {
     void *user_pages_start;     /* Start of the pages backing this zone */
@@ -430,6 +433,7 @@ typedef struct {
     bool internally_managed;                           /* Zones can be managed by iso_alloc or custom */
     bool is_full;                                      /* Indicates whether this zone is full to avoid expensive free bit slot searches */
     uint16_t index;                                    /* Zone index */
+    uint16_t next_sz_index;                            /* What is the index of the next zone of this size */
 #if CPU_PIN
     uint8_t cpu_core; /* What CPU core this zone is pinned to */
 #endif

--- a/misc/commands.gdb
+++ b/misc/commands.gdb
@@ -4,3 +4,5 @@ i r
 x/i $pc
 thread apply all bt
 thread apply all info locals
+p *_root
+p _zone_lookup_table

--- a/src/iso_alloc_profiler.c
+++ b/src/iso_alloc_profiler.c
@@ -148,7 +148,7 @@ INTERNAL_HIDDEN uint64_t __iso_alloc_mem_usage() {
         iso_alloc_zone *zone = &_root->zones[i];
         mem_usage += zone->bitmap_size;
         mem_usage += ZONE_USER_SIZE;
-        LOG("Zone[%d] holds %d byte chunks, megabytes (%d)", zone->index, zone->chunk_size, (ZONE_USER_SIZE / MEGABYTE_SIZE));
+        LOG("Zone[%d] holds %d byte chunks, megabytes (%d) next zone = %d", zone->index, zone->chunk_size, (ZONE_USER_SIZE / MEGABYTE_SIZE), zone->next_sz_index);
     }
 
     return (mem_usage / MEGABYTE_SIZE);


### PR DESCRIPTION
This adds more performance improvements related to issue #51. Zones are linked by their `next_sz_index` member which tells the allocator where in the `_root->zones` array it can find the next zone that holds the same size chunks. The new zone lookup table helps us find the first zone that holds a specific size in O(1) time.