### PR TITLE
add malloc and alloc_size attributes, run clang-format

### DIFF
--- a/include/iso_alloc.h
+++ b/include/iso_alloc.h
@@ -11,22 +11,28 @@
 
 #define NO_DISCARD __attribute__((warn_unused_result))
 
+#define MALLOC_ATTR __attribute__((malloc))
+#define ALLOC_SIZE __attribute__((alloc_size(1)))
+#define CALLOC_SIZE __attribute__((alloc_size(1, 2)))
+#define REALLOC_SIZE __attribute__((alloc_size(2)))
+#define ZONE_ALLOC_SIZE __attribute__((alloc_size(2)))
+
 typedef void iso_alloc_zone_handle;
 
 #if CPP_SUPPORT
 extern "C" {
 #endif
-EXTERNAL_API NO_DISCARD void *iso_alloc(size_t size);
-EXTERNAL_API NO_DISCARD void *iso_calloc(size_t nmemb, size_t size);
+EXTERNAL_API NO_DISCARD MALLOC_ATTR ALLOC_SIZE void *iso_alloc(size_t size);
+EXTERNAL_API NO_DISCARD MALLOC_ATTR CALLOC_SIZE void *iso_calloc(size_t nmemb, size_t size);
+EXTERNAL_API NO_DISCARD MALLOC_ATTR REALLOC_SIZE void *iso_realloc(void *p, size_t size);
 EXTERNAL_API void iso_free(void *p);
 EXTERNAL_API void iso_free_permanently(void *p);
-EXTERNAL_API NO_DISCARD void *iso_realloc(void *p, size_t size);
 EXTERNAL_API size_t iso_chunksz(void *p);
 EXTERNAL_API NO_DISCARD char *iso_strdup(const char *str);
 EXTERNAL_API NO_DISCARD char *iso_strdup_from_zone(iso_alloc_zone_handle *zone, const char *str);
 EXTERNAL_API NO_DISCARD char *iso_strndup(const char *str, size_t n);
 EXTERNAL_API NO_DISCARD char *iso_strndup_from_zone(iso_alloc_zone_handle *zone, const char *str, size_t n);
-EXTERNAL_API NO_DISCARD iso_alloc_zone_handle *iso_alloc_from_zone(iso_alloc_zone_handle *zone, size_t size);
+EXTERNAL_API NO_DISCARD MALLOC_ATTR ZONE_ALLOC_SIZE iso_alloc_zone_handle *iso_alloc_from_zone(iso_alloc_zone_handle *zone, size_t size);
 EXTERNAL_API NO_DISCARD iso_alloc_zone_handle *iso_alloc_new_zone(size_t size);
 EXTERNAL_API void iso_alloc_destroy_zone(iso_alloc_zone_handle *zone);
 EXTERNAL_API void iso_alloc_protect_root();

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -296,7 +296,7 @@ using namespace std;
 #define BIG_ZONE_USER_PAGE_COUNT 2
 #define BIG_ZONE_USER_PAGE_COUNT_SHIFT 1
 
-#define ZONE_LOOKUP_TABLE_SZ ((SMALL_SZ_MAX+1) * sizeof(uint16_t))
+#define ZONE_LOOKUP_TABLE_SZ ((SMALL_SZ_MAX + 1) * sizeof(uint16_t))
 
 /* We allocate zones at startup for common sizes.
  * Each of these default zones is ZONE_USER_SIZE bytes

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -1447,9 +1447,9 @@ INTERNAL_HIDDEN INLINE void check_big_canary(iso_alloc_big_zone *big) {
  * unbounded string reads from leaking it */
 INTERNAL_HIDDEN INLINE void write_canary(iso_alloc_zone *zone, void *p) {
     uint64_t canary = (zone->canary_secret ^ (uint64_t) p) & CANARY_VALIDATE_MASK;
-    *(uint64_t *)p = canary;
+    *(uint64_t *) p = canary;
     p += (zone->chunk_size - sizeof(uint64_t));
-    *(uint64_t *)p = canary;
+    *(uint64_t *) p = canary;
 }
 
 /* Verify the canary value in an allocation */

--- a/src/iso_alloc_interfaces.c
+++ b/src/iso_alloc_interfaces.c
@@ -4,11 +4,11 @@
 #include "iso_alloc.h"
 #include "iso_alloc_internal.h"
 
-EXTERNAL_API NO_DISCARD void *iso_alloc(size_t size) {
+EXTERNAL_API NO_DISCARD MALLOC_ATTR ALLOC_SIZE void *iso_alloc(size_t size) {
     return _iso_alloc(NULL, size);
 }
 
-EXTERNAL_API NO_DISCARD void *iso_calloc(size_t nmemb, size_t size) {
+EXTERNAL_API NO_DISCARD MALLOC_ATTR CALLOC_SIZE void *iso_calloc(size_t nmemb, size_t size) {
     return _iso_calloc(nmemb, size);
 }
 
@@ -24,7 +24,7 @@ EXTERNAL_API size_t iso_chunksz(void *p) {
     return _iso_chunk_size(p);
 }
 
-EXTERNAL_API NO_DISCARD void *iso_realloc(void *p, size_t size) {
+EXTERNAL_API NO_DISCARD MALLOC_ATTR REALLOC_SIZE void *iso_realloc(void *p, size_t size) {
     if(UNLIKELY(size == 0)) {
         iso_free(p);
         return NULL;
@@ -111,7 +111,7 @@ EXTERNAL_API NO_DISCARD char *iso_strndup_from_zone(iso_alloc_zone_handle *zone,
     return p;
 }
 
-EXTERNAL_API NO_DISCARD iso_alloc_zone_handle *iso_alloc_from_zone(iso_alloc_zone_handle *zone, size_t size) {
+EXTERNAL_API NO_DISCARD MALLOC_ATTR ZONE_ALLOC_SIZE iso_alloc_zone_handle *iso_alloc_from_zone(iso_alloc_zone_handle *zone, size_t size) {
     if(zone == NULL) {
         return NULL;
     }


### PR DESCRIPTION
Address issue #40. Im not including these attributes on `strdup` style functions because there is still debate as to whether they meet the definition.