### PR TITLE
fix issue where we look for chunk size but its zero page

### DIFF
--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -808,9 +808,9 @@ INTERNAL_HIDDEN iso_alloc_zone *is_zone_usable(iso_alloc_zone *zone, size_t size
     /* If the cache for this zone is empty we should
      * refill it to make future allocations faster 
      * for all threads */
-    if(zone->free_bit_slot_cache_usable >= zone->free_bit_slot_cache_index) {
-        fill_free_bit_slot_cache(zone);
-    }
+    //if(zone->free_bit_slot_cache_usable >= zone->free_bit_slot_cache_index) {
+    //    fill_free_bit_slot_cache(zone);
+    //}
 
     bit_slot_t bit_slot = get_next_free_bit_slot(zone);
 
@@ -1730,6 +1730,12 @@ INTERNAL_HIDDEN size_t _iso_chunk_size(void *p) {
     if(p == NULL) {
         return 0;
     }
+
+#if NO_ZERO_ALLOCATIONS
+    if(p == _zero_alloc_page) {
+        return 0;
+    }
+#endif
 
 #if ALLOC_SANITY
     LOCK_SANITY_CACHE();


### PR DESCRIPTION
Fix issue #56 where a 0 sized allocation is made (and `NO_ZERO_ALLOCATIONS` is enabled) and we try to iterate zones in iso_chunk_size to get the chunk size and abort when we can't find any zone.