### PR TITLE
add mutex for sanity mode

### DIFF
--- a/include/iso_alloc_sanity.h
+++ b/include/iso_alloc_sanity.h
@@ -27,14 +27,22 @@
 #define SANITY_CANARY_SIZE 8
 
 #if THREAD_SUPPORT
+#if USE_SPINLOCK
 extern atomic_flag sane_cache_flag;
-
 #define LOCK_SANITY_CACHE() \
     do {                    \
     } while(atomic_flag_test_and_set(&sane_cache_flag));
 
 #define UNLOCK_SANITY_CACHE() \
     atomic_flag_clear(&sane_cache_flag);
+#else // USE_SPINLOCK
+extern pthread_mutex_t sane_cache_mutex;
+#define LOCK_SANITY_CACHE() \
+    pthread_mutex_lock(&sane_cache_mutex);
+
+#define UNLOCK_SANITY_CACHE() \
+    pthread_mutex_unlock(&sane_cache_mutex);
+#endif
 #else
 #define LOCK_SANITY_CACHE()
 #define UNLOCK_SANITY_CACHE()

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -364,6 +364,9 @@ __attribute__((constructor(FIRST_CTOR))) void iso_alloc_ctor(void) {
 #if THREAD_SUPPORT && !USE_SPINLOCK
     pthread_mutex_init(&root_busy_mutex, NULL);
     pthread_mutex_init(&big_zone_busy_mutex, NULL);
+#if ALLOC_SANITY
+    pthread_mutex_init(&sane_cache_mutex, NULL);
+#endif
 #endif
 
     g_page_size = sysconf(_SC_PAGESIZE);

--- a/src/iso_alloc_sanity.c
+++ b/src/iso_alloc_sanity.c
@@ -4,7 +4,15 @@
 #include "iso_alloc_internal.h"
 
 #if ALLOC_SANITY
+
+#if THREAD_SUPPORT
+#if USE_SPINLOCK
 atomic_flag sane_cache_flag;
+#else
+pthread_mutex_t sane_cache_mutex;
+#endif
+#endif
+
 uint64_t _sanity_canary;
 int32_t _sane_sampled;
 uint8_t _sane_cache[SANE_CACHE_SIZE];


### PR DESCRIPTION
This adds a mutex for `ALLOC_SANITY` mode so the `USE_SPINLOCK` semantics apply here.