### PR TITLE
Minor perf fixes, new verify_zone checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,9 +270,9 @@ perf_tests: clean
 	$(CC) $(CFLAGS) $(C_SRCS) $(GDB_FLAGS) $(PERF_FLAGS) tests/tests.c -o $(BUILD_DIR)/tests_gprof
 	$(CC) $(CFLAGS) $(C_SRCS) $(GDB_FLAGS) $(PERF_FLAGS) tests/big_tests.c -o $(BUILD_DIR)/big_tests_gprof
 	$(BUILD_DIR)/tests_gprof
-	gprof -b $(BUILD_DIR)/tests_gprof gmon.out > tests_perf_analysis.txt
+	gprof -bl $(BUILD_DIR)/tests_gprof gmon.out > tests_perf_analysis.txt
 	$(BUILD_DIR)/big_tests_gprof
-	gprof -b $(BUILD_DIR)/big_tests_gprof gmon.out > big_tests_perf_analysis.txt
+	gprof -bl $(BUILD_DIR)/big_tests_gprof gmon.out > big_tests_perf_analysis.txt
 
 ## Runs a single test that prints CPU time
 ## compared to the same malloc/free operations

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -200,7 +200,7 @@ using namespace std;
 #define ROOT_NAME "isoalloc root"
 #define ZONE_BITMAP_NAME "isoalloc zone bitmap"
 #define INTERNAL_UZ_NAME "internal isoalloc user zone"
-#define PRIVAET_UZ_NAME "private isoalloc user zone"
+#define PRIVATE_UZ_NAME "private isoalloc user zone"
 #else
 #define SAMPLED_ALLOC_NAME ""
 #define BIG_ZONE_UD_NAME ""
@@ -399,7 +399,7 @@ static uint64_t default_zones[] = {ZONE_256, ZONE_256, ZONE_512, ZONE_512};
 static uint64_t default_zones[] = {ZONE_512, ZONE_512, ZONE_512, ZONE_1024};
 #endif
 
-typedef uint64_t bit_slot_t;
+typedef int64_t bit_slot_t;
 typedef int64_t bitmap_index_t;
 typedef uint16_t zone_lookup_table_t;
 typedef uint16_t chunk_lookup_table_t;
@@ -584,6 +584,7 @@ INTERNAL_HIDDEN bit_slot_t iso_scan_zone_free_slot(iso_alloc_zone *zone);
 INTERNAL_HIDDEN bit_slot_t get_next_free_bit_slot(iso_alloc_zone *zone);
 INTERNAL_HIDDEN iso_alloc_root *iso_alloc_new_root(void);
 INTERNAL_HIDDEN bool iso_does_zone_fit(iso_alloc_zone *zone, size_t size);
+INTERNAL_HIDDEN void _iso_free_internal_unlocked(void *p, bool permanent, iso_alloc_zone *zone);
 INTERNAL_HIDDEN void flush_thread_caches(void);
 INTERNAL_HIDDEN void iso_free_chunk_from_zone(iso_alloc_zone *zone, void *p, bool permanent);
 INTERNAL_HIDDEN void create_canary_chunks(iso_alloc_zone *zone);

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -1228,7 +1228,14 @@ INTERNAL_HIDDEN void *_iso_alloc(iso_alloc_zone *zone, size_t size) {
         } else {
             /* Extra Slow Path: We need a new zone in order
              * to satisfy this allocation request */
-            zone = _iso_new_zone(size, true);
+            if(size > MAX_DEFAULT_ZONE_SZ) {
+                zone = _iso_new_zone(size, true);
+            } else {
+                /* For chunks smaller than MAX_DEFAULT_ZONE_SZ bytes
+                 * we bump the size up to the next power of 2 */
+                size = next_pow2(size);
+                zone = _iso_new_zone(size, true);
+            }
 
             if(UNLIKELY(zone == NULL)) {
                 LOG_AND_ABORT("Failed to create a zone for allocation of %zu bytes", size);


### PR DESCRIPTION
* Iterating on perf issues like expensive checks in the free hot path
* Pass -l to gprof in performance tests to get more line level information
* Move zone retirement check into its own function for readability
* Adds some simple consistency checks in the verify_zone functionality
* Fix typo in define for Android builds