### PR TITLE
Clean up thread caches and chunk sizes

### DIFF
--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -428,8 +428,8 @@ typedef struct {
 } __attribute__((aligned(sizeof(int64_t)))) iso_alloc_zone;
 
 /* The size of the thread cache */
-#define THREAD_ZONE_CACHE_SZ 8
-#define THREAD_CHUNK_QUARANTINE_SZ 64
+#define ZONE_CACHE_SZ 8
+#define CHUNK_QUARANTINE_SZ 64 * sizeof(uintptr_t)
 
 /* Each thread gets a local cache of the most recently
  * used zones. This can greatly speed up allocations
@@ -513,6 +513,13 @@ typedef struct {
     iso_alloc_zone *zones;
     size_t zones_size;
 } __attribute__((aligned(sizeof(int64_t)))) iso_alloc_root;
+
+typedef struct {
+    void *user_pages_start;
+    void *bitmap_start;
+    uint32_t bitmap_size;
+    uint8_t ttl;
+} __attribute__((aligned(sizeof(int64_t)))) zone_quarantine_t;
 
 #if NO_ZERO_ALLOCATIONS
 extern void *_zero_alloc_page;

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -303,6 +303,8 @@ using namespace std;
 #define CHUNK_TO_ZONE_TABLE_SZ (65535 * sizeof(uint16_t))
 #define ADDR_TO_CHUNK_TABLE(p) (((uintptr_t) p >> 32) & 0xffff)
 
+#define ALLOCATED_BITSLOTS 0x5555555555555555
+
 /* We allocate zones at startup for common sizes.
  * Each of these default zones is ZONE_USER_SIZE bytes
  * so ZONE_8192 holds less chunks than ZONE_128 for
@@ -422,6 +424,7 @@ typedef struct {
     uint16_t next_sz_index;                            /* What is the index of the next zone of this size */
     uint32_t alloc_count;                              /* Total number of lifetime allocations */
     uint32_t af_count;                                 /* Increment/Decrement with each alloc/free operation */
+    uint8_t canary_count;                              /* How many canaries are in this zone? */
 #if CPU_PIN
     uint8_t cpu_core; /* What CPU core this zone is pinned to */
 #endif
@@ -429,7 +432,7 @@ typedef struct {
 
 /* The size of the thread cache */
 #define ZONE_CACHE_SZ 8
-#define CHUNK_QUARANTINE_SZ 64 * sizeof(uintptr_t)
+#define CHUNK_QUARANTINE_SZ 64
 
 /* Each thread gets a local cache of the most recently
  * used zones. This can greatly speed up allocations
@@ -578,6 +581,8 @@ INTERNAL_HIDDEN INLINE void insert_free_bit_slot(iso_alloc_zone *zone, int64_t b
 INTERNAL_HIDDEN INLINE void write_canary(iso_alloc_zone *zone, void *p);
 INTERNAL_HIDDEN INLINE void populate_thread_cache(iso_alloc_zone *zone);
 INTERNAL_HIDDEN INLINE void _flush_thread_caches(void);
+INTERNAL_HIDDEN INLINE void clear_chunk_quarantine(void);
+INTERNAL_HIDDEN INLINE void clear_zone_cache(void);
 INTERNAL_HIDDEN iso_alloc_zone *is_zone_usable(iso_alloc_zone *zone, size_t size);
 INTERNAL_HIDDEN iso_alloc_zone *iso_find_zone_fit(size_t size);
 INTERNAL_HIDDEN iso_alloc_zone *iso_new_zone(size_t size, bool internal);
@@ -588,6 +593,7 @@ INTERNAL_HIDDEN bit_slot_t iso_scan_zone_free_slot_slow(iso_alloc_zone *zone);
 INTERNAL_HIDDEN bit_slot_t iso_scan_zone_free_slot(iso_alloc_zone *zone);
 INTERNAL_HIDDEN bit_slot_t get_next_free_bit_slot(iso_alloc_zone *zone);
 INTERNAL_HIDDEN iso_alloc_root *iso_alloc_new_root(void);
+INTERNAL_HIDDEN bool is_pow2(uint64_t sz);
 INTERNAL_HIDDEN bool iso_does_zone_fit(iso_alloc_zone *zone, size_t size);
 INTERNAL_HIDDEN void _iso_free_internal_unlocked(void *p, bool permanent, iso_alloc_zone *zone);
 INTERNAL_HIDDEN void flush_thread_caches(void);

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -200,7 +200,7 @@ INTERNAL_HIDDEN void _verify_zone(iso_alloc_zone *zone) {
             /* If this bit is set it is either a free chunk or
              * a canary chunk. Either way it should have a set
              * of canaries we can verify */
-            if(bm[i] != 0 && (GET_BIT(bm[i], j)) == 1) {
+            if((GET_BIT(bm[i], j)) == 1) {
                 bit_slot = (i << BITS_PER_QWORD_SHIFT) + j;
                 void *p = POINTER_FROM_BITSLOT(zone, bit_slot);
                 check_canary(zone, p);
@@ -251,7 +251,7 @@ INTERNAL_HIDDEN INLINE void fill_free_bit_slot_cache(iso_alloc_zone *zone) {
                 return;
             }
 
-            if(bm[bm_idx] <= ALLOCATED_BITSLOTS && (GET_BIT(bm[bm_idx], j)) == 0) {
+            if((GET_BIT(bm[bm_idx], j)) == 0) {
                 bit_slot = (bm_idx << BITS_PER_QWORD_SHIFT) + j;
                 zone->free_bit_slot_cache[free_bit_slot_cache_index] = bit_slot;
                 free_bit_slot_cache_index++;
@@ -812,7 +812,7 @@ INTERNAL_HIDDEN bit_slot_t iso_scan_zone_free_slot_slow(iso_alloc_zone *zone) {
 
     for(bitmap_index_t i = 0; i < max_bm_idx; i++) {
         for(int64_t j = 0; j < BITS_PER_QWORD; j += BITS_PER_CHUNK) {
-            if(bm[i] != -1 && (GET_BIT(bm[i], j)) == 0) {
+            if((GET_BIT(bm[i], j)) == 0) {
                 bit_slot = (i << BITS_PER_QWORD_SHIFT) + j;
                 return bit_slot;
             }

--- a/src/iso_alloc_util.c
+++ b/src/iso_alloc_util.c
@@ -82,6 +82,10 @@ INTERNAL_HIDDEN int32_t name_mapping(void *p, size_t sz, const char *name) {
 #endif
 }
 
+INTERNAL_HIDDEN bool is_pow2(uint64_t sz) {
+    return (sz & (sz - 1)) == 0;
+}
+
 INTERNAL_HIDDEN size_t next_pow2(size_t sz) {
     sz |= sz >> 1;
     sz |= sz >> 2;


### PR DESCRIPTION
* Rename thread caches, enable them with or without thread support. When used without thread support these will be securely mmap'd and not live in TLS
* Ensure all allocation sizes are a power of 2 which ensures bitmaps are a power of 2, which ultimately means memory savings and more efficient searches
* Store canary_count in zones (this may become conditional on canaries being enabled)
* Add unused zone_quarantine_t structure. Soon to be used