### PR TITLE
Perf and cache fixes

### DIFF
--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -46,9 +46,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <sys/mman.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 #include "iso_alloc.h"
 
@@ -492,7 +492,7 @@ INTERNAL_HIDDEN INLINE void fill_free_bit_slot_cache(iso_alloc_zone_t *zone);
 INTERNAL_HIDDEN INLINE void insert_free_bit_slot(iso_alloc_zone_t *zone, int64_t bit_slot);
 INTERNAL_HIDDEN INLINE void write_canary(iso_alloc_zone_t *zone, void *p);
 INTERNAL_HIDDEN INLINE void populate_zone_cache(iso_alloc_zone_t *zone);
-INTERNAL_HIDDEN INLINE void _flush_zone_caches(void);
+INTERNAL_HIDDEN INLINE void _flush_chunk_quarantine(void);
 INTERNAL_HIDDEN INLINE void clear_chunk_quarantine(void);
 INTERNAL_HIDDEN INLINE void clear_zone_cache(void);
 INTERNAL_HIDDEN iso_alloc_zone_t *is_zone_usable(iso_alloc_zone_t *zone, size_t size);
@@ -508,7 +508,7 @@ INTERNAL_HIDDEN iso_alloc_root *iso_alloc_new_root(void);
 INTERNAL_HIDDEN bool is_pow2(uint64_t sz);
 INTERNAL_HIDDEN bool iso_does_zone_fit(iso_alloc_zone_t *zone, size_t size);
 INTERNAL_HIDDEN void _iso_free_internal_unlocked(void *p, bool permanent, iso_alloc_zone_t *zone);
-INTERNAL_HIDDEN void flush_zone_caches(void);
+INTERNAL_HIDDEN void flush_caches(void);
 INTERNAL_HIDDEN void iso_free_chunk_from_zone(iso_alloc_zone_t *zone, void *p, bool permanent);
 INTERNAL_HIDDEN void create_canary_chunks(iso_alloc_zone_t *zone);
 INTERNAL_HIDDEN void iso_alloc_initialize_global_root(void);

--- a/src/iso_alloc_interfaces.c
+++ b/src/iso_alloc_interfaces.c
@@ -210,7 +210,7 @@ EXTERNAL_API void iso_verify_zone(iso_alloc_zone_handle *zone) {
 }
 
 EXTERNAL_API void iso_flush_caches() {
-    flush_zone_caches();
+    flush_caches();
 }
 
 #if HEAP_PROFILER

--- a/src/iso_alloc_sanity.c
+++ b/src/iso_alloc_sanity.c
@@ -213,6 +213,7 @@ INTERNAL_HIDDEN void *_iso_alloc_sample(size_t size) {
     _sane_allocation_t *sane_alloc = NULL;
 
     LOCK_SANITY_CACHE();
+    UNLOCK_ROOT();
 
     /* Find the first free slot in our sampled storage */
     for(uint32_t i = 0; i < MAX_SANE_SAMPLES; i++) {


### PR DESCRIPTION
* The zone cache doesn't need a lock, its either TLS or global in a single threaded use case
* When sampling an allocation in sanity mode we don't need to hold the lock longer than necessary