### PR TITLE
add USE_MLOCK define for optional mlock use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,10 @@ ABORT_ON_NULL = -DABORT_ON_NULL=0
 ## Enable protection against misusing 0 sized allocations
 NO_ZERO_ALLOCATIONS = -DNO_ZERO_ALLOCATIONS=1
 
+## Enables mlock() on performance sensitive pages. For lower
+## end devices with less memory you may want to disable this
+USE_MLOCK = -DUSE_MLOCK=1
+
 LIBNAME = libisoalloc.so
 
 UNAME := $(shell uname)
@@ -173,7 +177,7 @@ endif
 CFLAGS = $(COMMON_CFLAGS) $(SECURITY_FLAGS) $(BUILD_ERROR_FLAGS) $(HOOKS) $(HEAP_PROFILER) -fvisibility=hidden \
 	-std=c11 $(SANITIZER_SUPPORT) $(ALLOC_SANITY) $(UNINIT_READ_SANITY) $(CPU_PIN) $(EXPERIMENTAL) $(UAF_PTR_PAGE) \
 	$(VERIFY_BIT_SLOT_CACHE) $(NAMED_MAPPINGS) $(ABORT_ON_NULL) $(NO_ZERO_ALLOCATIONS) $(ABORT_NO_ENTROPY) \
-	$(ISO_DTOR_CLEANUP) $(SHUFFLE_BIT_SLOT_CACHE) $(USE_SPINLOCK) -pthread $(HUGE_PAGES)
+	$(ISO_DTOR_CLEANUP) $(SHUFFLE_BIT_SLOT_CACHE) $(USE_SPINLOCK) -pthread $(HUGE_PAGES) $(USE_MLOCK)
 CXXFLAGS = $(COMMON_CFLAGS) -DCPP_SUPPORT=1 -std=c++17 $(SANITIZER_SUPPORT) $(HOOKS)
 EXE_CFLAGS = -fPIE
 GDB_FLAGS = -g -ggdb3 -fno-omit-frame-pointer

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -18,7 +18,7 @@ Default zones for common sizes are created in the library constructor. This help
 
 By default user chunks are not sanitized upon free. While this helps mitigate uninitialized memory vulnerabilities it is a very slow operation. You can enable this feature by changing the `SANITIZE_CHUNKS` flag in the Makefile.
 
-The meta data for the IsoAlloc root will be locked with `mlock`. This means this data will never be swapped to disk. We do this because using this data structure is required for both the alloc and free paths. This operation may fail if we are running inside a container with memory limits. Failure to lock the memory will not cause an abort and the error will be silently ignored in the initialization of the root structure.
+When `USE_MLOCK` is enabled in the Makefile (on by default) the meta data for the IsoAlloc root and other caches will be locked with `mlock`. This means this data will never be swapped to disk. We do this because using these data structures is required for both the alloc and free hot paths. This operation may fail if we are running inside a container with memory limits. Failure to lock the memory will not cause an abort and all failures will be silently ignored.
 
 If you know your program will not require multi-threaded access to IsoAlloc you can disable threading support by setting the `THREAD_SUPPORT` define to 0 in the Makefile. This will remove all atomic/mutex lock/unlock operations from the allocator, which will result in significant performance gains in some programs. If you do require thread support then you may want to profile your program to determine what default zone sizes will benefit performance.
 

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -8,7 +8,7 @@ LOCAL_CFLAGS := -DTHREAD_SUPPORT=1 -pthread									\
 	-Wno-format-pedantic -DMALLOC_HOOK=1 -fvisibility=hidden -std=c11		\
 	-DALLOC_SANITY=0 -DUNINIT_READ_SANITY=0 -DCPU_PIN=0 -DEXPERIMENTAL=0	\
 	-DUAF_PTR_PAGE=0 -DVERIFY_BIT_SLOT_CACHE=0 -DNAMED_MAPPINGS=1 -fPIC		\
-	-shared -DDEBUG=1 -DLEAK_DETECTOR=1 -DMEM_USAGE=1 						\
+	-shared -DDEBUG=1 -DLEAK_DETECTOR=1 -DMEM_USAGE=1 -DUSE_MLOCK=1			\
 	-g -ggdb3 -fno-omit-frame-pointer
 
 LOCAL_SRC_FILES := ../../src/iso_alloc.c ../../src/iso_alloc_printf.c ../../src/iso_alloc_random.c				\

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -139,6 +139,13 @@ using namespace std;
 #define IS_POISONED_RANGE(ptr, size) 0
 #endif
 
+#if USE_MLOCK
+#define MLOCK(p, s) \
+    mlock(p, s);
+#else
+#define MLOCK(p, s)
+#endif
+
 #define OK 0
 #define ERR -1
 

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -350,7 +350,7 @@ INTERNAL_HIDDEN void iso_alloc_initialize_global_root(void) {
 
     /* We mlock the root or every allocation would
      * result in a soft page fault */
-    mlock(&_root, sizeof(iso_alloc_root));
+    MLOCK(&_root, sizeof(iso_alloc_root));
 
     _root->zones_size = (MAX_ZONES * sizeof(iso_alloc_zone_t));
     _root->zones_size += (g_page_size * 2);
@@ -370,23 +370,23 @@ INTERNAL_HIDDEN void iso_alloc_initialize_global_root(void) {
     create_guard_page(chunk_quarantine);
     chunk_quarantine = chunk_quarantine + (g_page_size / sizeof(uintptr_t));
     create_guard_page((void *) chunk_quarantine + c);
-    mlock(chunk_quarantine, c);
+    MLOCK(chunk_quarantine, c);
 
     size_t z = ROUND_UP_PAGE(ZONE_CACHE_SZ * sizeof(_tzc));
     zone_cache = mmap_rw_pages(z + (g_page_size + 2), true, NULL);
     create_guard_page(zone_cache);
     zone_cache = ((void *) zone_cache) + g_page_size;
     create_guard_page((void *) zone_cache + z);
-    mlock(zone_cache, z);
+    MLOCK(zone_cache, z);
 #endif
 
     /* If we don't lock the these lookup tables we may incur
      * a soft page fault with almost every alloc/free */
     zone_lookup_table = mmap_rw_pages(ZONE_LOOKUP_TABLE_SZ, true, NULL);
-    mlock(&zone_lookup_table, ZONE_LOOKUP_TABLE_SZ);
+    MLOCK(&zone_lookup_table, ZONE_LOOKUP_TABLE_SZ);
 
     chunk_lookup_table = mmap_rw_pages(CHUNK_TO_ZONE_TABLE_SZ, true, NULL);
-    mlock(&chunk_lookup_table, CHUNK_TO_ZONE_TABLE_SZ);
+    MLOCK(&chunk_lookup_table, CHUNK_TO_ZONE_TABLE_SZ);
 
     for(int64_t i = 0; i < DEFAULT_ZONE_COUNT; i++) {
         if((_iso_new_zone(default_zones[i], true)) == NULL) {


### PR DESCRIPTION
* Add the `USE_MLOCK` define in the Makefile which can be used to enable/disable mlock usage on lower end / low memory devices