### PR TITLE
HUGE_PAGES flags usage for macOs.

### DIFF
--- a/include/conf.h
+++ b/include/conf.h
@@ -59,7 +59,7 @@
 /* See PERFORMANCE.md for notes on huge page sizes.
  * If your system uses a non-default value for huge
  * page sizes you will need to adjust that here */
-#if __linux__ && MAP_HUGETLB && HUGE_PAGES
+#if (__linux__ && MAP_HUGETLB) || (__APPLE__ && VM_FLAGS_SUPERPAGE_SIZE_2MB) && HUGE_PAGES
 #define HUGE_PAGE_SZ 2097152
 #endif
 

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -35,6 +35,7 @@
 #define ENVIRON environ
 #elif __APPLE__
 #include <libkern/OSByteOrder.h>
+#include <mach/vm_statistics.h>
 #define bswap_32(x) OSSwapInt32(x)
 #define bswap_64(x) OSSwapInt64(x)
 #define ENVIRON NULL


### PR DESCRIPTION
here we use the special file descriptor to put the zone
into a 2MB superpage.