### PR TITLE
5 19 2022 perf formatting

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ freebsd_instance:
 task:
   name: testsuite-freebsd-amd64
   install_script:
-    - pkg install bash gmake
+    - pkg install -y bash gmake
   script:
     - gmake tests
     - gmake cpp_tests

--- a/include/conf.h
+++ b/include/conf.h
@@ -49,9 +49,6 @@
  * of its current chunks are free */
 #define ZONE_ALLOC_RETIRE 32
 
-/* The size of our bit slot freelist */
-#define BIT_SLOT_CACHE_SZ 255
-
 /* This byte value will overwrite the contents
  * of all free'd user chunks if -DSANITIZE_CHUNKS
  * is enabled in the Makefile */
@@ -60,7 +57,7 @@
 /* See PERFORMANCE.md for notes on huge page sizes.
  * If your system uses a non-default value for huge
  * page sizes you will need to adjust that here */
-#if (__linux__ && MAP_HUGETLB) || (__APPLE__ && VM_FLAGS_SUPERPAGE_SIZE_2MB) || (__FreeBSD__ && MAP_HUGETLB) && HUGE_PAGES
+#if(__linux__ && MAP_HUGETLB) || (__APPLE__ && VM_FLAGS_SUPERPAGE_SIZE_2MB) || (__FreeBSD__ && MAP_HUGETLB) && HUGE_PAGES
 #define HUGE_PAGE_SZ 2097152
 #endif
 

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -361,15 +361,15 @@ typedef struct {
     uint64_t pointer_mask;                             /* Each zone has its own pointer protection secret */
     uint32_t chunk_size;                               /* Size of chunks managed by this zone */
     uint32_t bitmap_size;                              /* Size of the bitmap in bytes */
-    bitmap_index_t max_bitmap_idx;
-    bool internal;           /* Zones can be managed by iso_alloc or private */
-    bool is_full;            /* Flags whether this zone is full to avoid bit slot searches */
-    uint16_t index;          /* Zone index */
-    uint16_t next_sz_index;  /* What is the index of the next zone of this size */
-    uint32_t alloc_count;    /* Total number of lifetime allocations */
-    uint32_t af_count;       /* Increment/Decrement with each alloc/free operation */
-    uint32_t chunk_count;    /* Total number of chunks in this zone */
-    uint8_t chunk_size_pow2; /* Computed by _log2(chunk_size) at zone creation */
+    bitmap_index_t max_bitmap_idx;                     /* Max bitmap index for this bitmap */
+    bool internal;                                     /* Zones can be managed by iso_alloc or private */
+    bool is_full;                                      /* Flags whether this zone is full to avoid bit slot searches */
+    uint16_t index;                                    /* Zone index */
+    uint16_t next_sz_index;                            /* What is the index of the next zone of this size */
+    uint32_t alloc_count;                              /* Total number of lifetime allocations */
+    uint32_t af_count;                                 /* Increment/Decrement with each alloc/free operation */
+    uint32_t chunk_count;                              /* Total number of chunks in this zone */
+    uint8_t chunk_size_pow2;                           /* Computed by _log2(chunk_size) at zone creation */
 #if MEMORY_TAGGING
     bool tagged; /* Zone supports memory tagging */
 #endif

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -236,19 +236,16 @@ using namespace std;
     n &= ~(1UL << k);
 
 #define ALIGN_SZ_UP(n) \
-    ((((n) + (ALIGNMENT) - 1) >> 3 ) * ALIGNMENT)
+    ((((n + ALIGNMENT) - 1) >> 3) * ALIGNMENT)
 
 #define ALIGN_SZ_DOWN(n) \
-    ((((n) + (ALIGNMENT) -1) >> 3) * ALIGNMENT) - ALIGNMENT
+    ((((n + ALIGNMENT) - 1) >> 3) * ALIGNMENT) - ALIGNMENT
 
 #define ROUND_UP_PAGE(n) \
-  ((((n) + (g_page_size) - 1) >> g_page_size_shift) * (g_page_size))
+    ((((n + g_page_size) - 1) >> g_page_size_shift) * (g_page_size))
 
 #define ROUND_DOWN_PAGE(n) \
     (ROUND_UP_PAGE(n) - g_page_size)
-
-#define GET_MAX_BITMASK_INDEX(zone) \
-    (zone->bitmap_size >> 3)
 
 #define MASK_ZONE_PTRS(zone) \
     MASK_BITMAP_PTRS(zone);  \
@@ -336,8 +333,7 @@ extern uint32_t g_page_size_shift;
 /* iso_alloc makes a number of default zones for common
  * allocation sizes. Allocations are 'first fit' up until
  * ZONE_1024 at which point a new zone is created for that
- * specific size request. You can create additional startup
- * profile by adjusting the next few lines below. */
+ * specific size request. */
 #define DEFAULT_ZONE_COUNT sizeof(default_zones) >> 3
 
 #define MEM_TAG_SIZE 1
@@ -351,6 +347,8 @@ typedef int64_t bitmap_index_t;
 typedef uint16_t zone_lookup_table_t;
 typedef uint16_t chunk_lookup_table_t;
 
+#define BIT_SLOT_CACHE_SZ 255
+
 typedef struct {
     void *user_pages_start;     /* Start of the pages backing this zone */
     void *bitmap_start;         /* Start of the bitmap */
@@ -363,14 +361,15 @@ typedef struct {
     uint64_t pointer_mask;                             /* Each zone has its own pointer protection secret */
     uint32_t chunk_size;                               /* Size of chunks managed by this zone */
     uint32_t bitmap_size;                              /* Size of the bitmap in bytes */
-    bool internal;                                     /* Zones can be managed by iso_alloc or private */
-    bool is_full;                                      /* Flags whether this zone is full to avoid bit slot searches */
-    uint16_t index;                                    /* Zone index */
-    uint16_t next_sz_index;                            /* What is the index of the next zone of this size */
-    uint32_t alloc_count;                              /* Total number of lifetime allocations */
-    uint32_t af_count;                                 /* Increment/Decrement with each alloc/free operation */
-    uint32_t chunk_count;                              /* Total number of chunks in this zone */
-    uint8_t chunk_size_pow2;                           /* Computed by _log2(chunk_size) */
+    bitmap_index_t max_bitmap_idx;
+    bool internal;           /* Zones can be managed by iso_alloc or private */
+    bool is_full;            /* Flags whether this zone is full to avoid bit slot searches */
+    uint16_t index;          /* Zone index */
+    uint16_t next_sz_index;  /* What is the index of the next zone of this size */
+    uint32_t alloc_count;    /* Total number of lifetime allocations */
+    uint32_t af_count;       /* Increment/Decrement with each alloc/free operation */
+    uint32_t chunk_count;    /* Total number of chunks in this zone */
+    uint8_t chunk_size_pow2; /* Computed by _log2(chunk_size) at zone creation */
 #if MEMORY_TAGGING
     bool tagged; /* Zone supports memory tagging */
 #endif

--- a/src/iso_alloc_profiler.c
+++ b/src/iso_alloc_profiler.c
@@ -104,7 +104,7 @@ INTERNAL_HIDDEN uint64_t _iso_alloc_zone_leak_detector(iso_alloc_zone_t *zone, b
                  * canary value. If it doesn't validate then we assume
                  * its a true leak and increment the in_use counter */
                 bit_slot_t bit_slot = (i * BITS_PER_QWORD) + j;
-                const void *leak = (zone->user_pages_start + ((bit_slot / BITS_PER_CHUNK) * zone->chunk_size));
+                const void *leak = (zone->user_pages_start + ((bit_slot >> 1) * zone->chunk_size));
 
                 if(bit_two == 1 && (check_canary_no_abort(zone, leak) != ERR)) {
                     continue;

--- a/src/iso_alloc_util.c
+++ b/src/iso_alloc_util.c
@@ -48,7 +48,7 @@ INTERNAL_HIDDEN void *mmap_pages(size_t size, bool populate, const char *name, i
 #if MAP_HUGETLB && HUGE_PAGES
     /* If we are allocating pages for a user zone
      * then take advantage of the huge TLB */
-    if(size == ZONE_USER_SIZE || size == (ZONE_USER_SIZE / 2)) {
+    if(size == ZONE_USER_SIZE || size == (ZONE_USER_SIZE >> 1)) {
         flags |= MAP_HUGETLB;
     }
 #endif
@@ -56,7 +56,7 @@ INTERNAL_HIDDEN void *mmap_pages(size_t size, bool populate, const char *name, i
 #if VM_FLAGS_SUPERPAGE_SIZE_2MB && HUGE_PAGES
     /* If we are allocating pages for a user zone
      * we are going to use the 2 MB superpage flag */
-    if(size == ZONE_USER_SIZE || size == (ZONE_USER_SIZE / 2)) {
+    if(size == ZONE_USER_SIZE || size == (ZONE_USER_SIZE >> 1)) {
         fd = VM_FLAGS_SUPERPAGE_SIZE_2MB;
     }
 #endif
@@ -70,7 +70,7 @@ INTERNAL_HIDDEN void *mmap_pages(size_t size, bool populate, const char *name, i
     }
 
 #if __linux__ && MAP_HUGETLB && HUGE_PAGES && MADV_HUGEPAGE
-    if(size == ZONE_USER_SIZE || size == (ZONE_USER_SIZE / 2)) {
+    if(size == ZONE_USER_SIZE || size == (ZONE_USER_SIZE >> 1)) {
         madvise(p, size, MADV_HUGEPAGE);
     }
 #endif
@@ -121,10 +121,10 @@ INTERNAL_HIDDEN INLINE CONST size_t next_pow2(size_t sz) {
 }
 
 const uint32_t _log_table[32] = {
-    0,  9,  1, 10, 13, 21,  2, 29,
-    11, 14, 16, 18, 22, 25,  3, 30,
-    8, 12, 20, 28, 15, 17, 24,  7,
-    19, 27, 23,  6, 26,  5,  4, 31};
+    0, 9, 1, 10, 13, 21, 2, 29,
+    11, 14, 16, 18, 22, 25, 3, 30,
+    8, 12, 20, 28, 15, 17, 24, 7,
+    19, 27, 23, 6, 26, 5, 4, 31};
 
 /* Fast log2() implementation for 32 bit integers */
 INTERNAL_HIDDEN uint32_t _log2(uint32_t v) {
@@ -133,5 +133,5 @@ INTERNAL_HIDDEN uint32_t _log2(uint32_t v) {
     v |= v >> 4;
     v |= v >> 8;
     v |= v >> 16;
-    return _log_table[(uint32_t)(v*0x07C4ACDD) >> 27];
+    return _log_table[(uint32_t) (v * 0x07C4ACDD) >> 27];
 }

--- a/tests/alloc_fuzz.c
+++ b/tests/alloc_fuzz.c
@@ -13,7 +13,7 @@ uint32_t allocation_sizes[] = {ZONE_16, ZONE_32, ZONE_64, ZONE_128,
                                ZONE_256, ZONE_512, ZONE_1024,
                                ZONE_2048, ZONE_4096, ZONE_8192,
                                SMALL_SZ_MAX / 4, SMALL_SZ_MAX / 2,
-                               SMALL_SZ_MAX - 1, SMALL_SZ_MAX };
+                               SMALL_SZ_MAX - 1, SMALL_SZ_MAX};
 
 uint32_t array_sizes[] = {16, 32, 64, 128, 256, 512, 1024, 2048};
 


### PR DESCRIPTION
- Remove BIT_SLOT_CACHE_SZ from conf.h as modifying it larger than 255 requires modifying an internal header
- Formatting fixes from `clang format`
- Don't call madvise on unmapped pages
- Remove `GET_MAX_BITMASK_INDEX`, precompute max bitmap index and safe the runtime cost
- Minor perf improvements to division operators