### PR TITLE
update the use after free test for when UAF_PTR_PAGE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ tests: clean library_debug_unit_tests
 	@echo "make library_debug_unit_tests"
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) tests/tagged_ptr_test.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/tagged_ptr_test $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) tests/tests.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/tests $(LDFLAGS)
-	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) tests/uaf.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/uaf
+	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) tests/uaf.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/uaf $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) tests/interfaces_test.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/interfaces_test $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) tests/thread_tests.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/thread_tests $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(UNIT_TESTING) tests/big_canary_test.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/big_canary_test $(LDFLAGS)

--- a/tests/uaf.c
+++ b/tests/uaf.c
@@ -4,9 +4,10 @@
 #include "iso_alloc.h"
 #include "iso_alloc_internal.h"
 
-#if defined(UAF_PTR_PAGE) && !defined(ALLOC_SANITY)
-/* This test should be run manually. You need to enable UAF_PTR_PAGE
- * and then disable the sampling logic in iso_alloc. */
+#if UAF_PTR_PAGE && !ALLOC_SANITY
+/* This test should be run manually after enabling UAF_PTR_PAGE
+ * and disabling the sampling mechanism before the call to
+ * _iso_alloc_ptr_search in _iso_free_internal_unlocked */
 typedef struct test {
     char *str;
 } test_t;
@@ -15,14 +16,19 @@ int main(int argc, char *argv[]) {
     void *str = iso_alloc(32);
     test_t *test = (test_t *) iso_alloc(1024);
     test->str = str;
-    memcpy(str, "a string!", 9);
-    iso_free(str);
+
+    const char *s = "a string!";
+    memcpy(str, s, strlen(s));
+
+    /* We free the chunk permanently because
+     * it bypasses the quarantine */
+    iso_free_permanently(str);
 
     /* Dereference a pointer that should have been
      * detected and overwritten with UAF_PTR_PAGE */
-    LOG("Attempting to dereference test->str.\nWe should fault on %x", UAF_PTR_PAGE_ADDR);
-    LOG("%s", test->str);
-    iso_free(test);
+    fprintf(stdout, "Dereferencing test->str @ %p. Fault address will be %lx\n", test->str, UAF_PTR_PAGE_ADDR);
+    fprintf(stdout, "[%s]\n", test->str);
+    iso_free_permanently(test);
 
     return OK;
 }


### PR DESCRIPTION
* Update the use after free detection test and Makefile. It is still not tested by default
* Minor performance tweaks in `_iso_alloc_ptr_search`