### PR TITLE
make the size larger

### DIFF
--- a/tests/sized_free.c
+++ b/tests/sized_free.c
@@ -7,6 +7,6 @@
 int main(int argc, char *argv[]) {
     size_t size = 1024;
     uint8_t *p = iso_alloc(size);
-    iso_free_size(p, size * 2);
+    iso_free_size(p, size * 4);
     return 0;
 }


### PR DESCRIPTION
Change the size passed to `iso_free_size()` to determine why FreeBSD CI is failing