### PR TITLE
CPU_PIN support for mac M1 proposal.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,6 @@ LIBNAME = libisoalloc.so
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
 OS_FLAGS = -framework Security
-CPU_PIN =
 LIBNAME = libisoalloc.dylib
 endif
 

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -1,14 +1,14 @@
 LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
-LOCAL_CFLAGS := -DTHREAD_SUPPORT=1 -pthread									\
+LOCAL_CFLAGS := -DTHREAD_SUPPORT=1 -pthread						\
 	-DPRE_POPULATE_PAGES=0 -DSMALL_MEM_STARTUP=0 -DSANITIZE_CHUNKS=0		\
 	-DFUZZ_MODE=0 -DPERM_FREE_REALLOC=0 -DDISABLE_CANARY=0 -Werror			\
 	-pedantic -Wno-pointer-arith -Wno-gnu-zero-variadic-macro-arguments		\
 	-Wno-format-pedantic -DMALLOC_HOOK=1 -fvisibility=hidden -std=c11		\
-	-DALLOC_SANITY=0 -DUNINIT_READ_SANITY=0 -DCPU_PIN=0 -DEXPERIMENTAL=0	\
+	-DALLOC_SANITY=0 -DUNINIT_READ_SANITY=0 -DCPU_PIN=0 -DEXPERIMENTAL=0		\
 	-DUAF_PTR_PAGE=0 -DVERIFY_BIT_SLOT_CACHE=0 -DNAMED_MAPPINGS=1 -fPIC		\
-	-shared -DDEBUG=1 -DLEAK_DETECTOR=1 -DMEM_USAGE=1 -DUSE_MLOCK=1			\
+	-shared -DDEBUG=1 -DLEAK_DETECTOR=1 -DMEM_USAGE=1 -DUSE_MLOCK=1 -DSCHED_GETCPU	\
 	-g -ggdb3 -fno-omit-frame-pointer
 
 LOCAL_SRC_FILES := ../../src/iso_alloc.c ../../src/iso_alloc_printf.c ../../src/iso_alloc_random.c				\

--- a/src/iso_alloc_util.c
+++ b/src/iso_alloc_util.c
@@ -22,6 +22,19 @@ INTERNAL_HIDDEN INLINE int _iso_getcpu(void) {
                      : "=r"(a)
                      : "r"(cpunodesegment));
     return (int) (a & 0xfff);
+#elif defined(__aarch64__)
+#if __APPLE__
+    /* unlike other operating systems, the tpidr_el0 register on macOs
+     * is unused data stored for the current thread is instead fetchable
+     * from "tpidrro_el0".
+     */
+    uintptr_t a;
+    __asm__ volatile("mrs %x0, tpidrro_el0" : "=r"(a) :: "memory");
+    return (int)((a & 0x8) - 1);
+#else
+    /* TODO most likely different register/making on other platforms */
+    return -1;
+#endif
 #else
     return -1;
 #endif


### PR DESCRIPTION
we fetch the thread data from the tpidrr_el0 register specifically
for macOs and spplying a mask to get the cpuid.