### PR TITLE
Strict spatial sep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,14 @@ MEMCPY_SANITY = -DMEMCPY_SANITY=0
 ## and THREAD_SUPPORT are enabled. Linux only
 UNINIT_READ_SANITY = -DUNINIT_READ_SANITY=0
 
+## By default IsoAlloc may select a zone that holds chunks
+## that are larger than were requested. This is intended
+## to reduce memory consumpion and is only done for smaller
+## sizes. Enabling this feature configures IsoAlloc to only
+## use zones that are a perfect fit for the requested size
+## once its been rounded up to ALIGNMENT size (8)
+STRONG_SIZE_ISOLATION = -DSTRONG_SIZE_ISOLATION=0
+
 ## Enable a sampling mechanism that searches for references
 ## to a chunk currently being freed. The search only overwrites
 ## the first reference to that chunk because searching all
@@ -211,7 +219,7 @@ CFLAGS = $(COMMON_CFLAGS) $(SECURITY_FLAGS) $(BUILD_ERROR_FLAGS) $(HOOKS) $(HEAP
 	-std=c11 $(SANITIZER_SUPPORT) $(ALLOC_SANITY) $(MEMCPY_SANITY) $(UNINIT_READ_SANITY) $(CPU_PIN) $(SCHED_GETCPU) \
 	$(EXPERIMENTAL) $(UAF_PTR_PAGE) $(VERIFY_BIT_SLOT_CACHE) $(NAMED_MAPPINGS) $(ABORT_ON_NULL) $(NO_ZERO_ALLOCATIONS) \
 	$(ABORT_NO_ENTROPY) $(ISO_DTOR_CLEANUP) $(SHUFFLE_BIT_SLOT_CACHE) $(USE_SPINLOCK) $(HUGE_PAGES) $(USE_MLOCK) \
-	$(MEMORY_TAGGING)
+	$(MEMORY_TAGGING) $(STRONG_SIZE_ISOLATION)
 CXXFLAGS = $(COMMON_CFLAGS) -DCPP_SUPPORT=1 -std=c++17 $(SANITIZER_SUPPORT) $(HOOKS)
 EXE_CFLAGS = -fPIE
 GDB_FLAGS = -g -ggdb3 -fno-omit-frame-pointer

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ When enabled, the `CPU_PIN` feature will restrict allocations from a given zone 
 * When `SHUFFLE_BIT_SLOT_CACHE` is enabled IsoAlloc will shuffle the bit slot cache upon creation (3-4x perf hit)
 * When destroying private zones if `NEVER_REUSE_ZONES` is enabled IsoAlloc won't attempt to repurpose the zone
 * Zones are retired and replaced after they've allocated and freed a specific number of chunks. This is calculated as `ZONE_ALLOC_RETIRE * max_chunk_count_for_zone`.
-* When `MEMORY_TAGGING` is enabled IsoAlloc will create a 1 byte tag for each chunk in private zones. See the [MEMORY_TAGGING.md](MEMORY_TAGGING.md) documentation, or [this test](tests/tagged_ptr_test.cpp) for an example of how to use it.
-* When `MEMCPY_SANITY` is enabled the allocator will hook all calls to `memcpy` and check for out of bounds r/w operations when either src or dst points to a chunk allocated by IsoAlloc
+* `MEMORY_TAGGING` When enabled IsoAlloc will create a 1 byte tag for each chunk in private zones. See the [MEMORY_TAGGING.md](MEMORY_TAGGING.md) documentation, or [this test](tests/tagged_ptr_test.cpp) for an example of how to use it.
+* `MEMCPY_SANITY` Configures the allocator will hook all calls to `memcpy` and check for out of bounds r/w operations when either src or dst points to a chunk allocated by IsoAlloc
+* `STRONG_SIZE_ISOLATION` Enables a policy that enforces stronger memory isolation by size
 
 ## Building
 

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -1050,7 +1050,8 @@ INTERNAL_HIDDEN ASSUME_ALIGNED void *_iso_alloc(iso_alloc_zone_t *zone, size_t s
     }
 #endif
 
-    if((is_pow2(size)) != true) {
+    /* Sizes are always a power of 2, even for private zones */
+    if(size < SMALL_SZ_MAX && is_pow2(size) != true) {
         size = next_pow2(size);
     }
 

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -801,6 +801,12 @@ INTERNAL_HIDDEN iso_alloc_zone_t *is_zone_usable(iso_alloc_zone_t *zone, size_t 
         return NULL;
     }
 
+#if STRONG_SIZE_ISOLATION
+    if(UNLIKELY(zone->internal == false && size != zone->chunk_size)) {
+        return NULL;
+    }
+#endif
+
     /* This zone may fit this chunk but if the zone was
      * created for chunks more than (N * larger) than the
      * requested allocation size then we would be wasting
@@ -1019,9 +1025,14 @@ INTERNAL_HIDDEN INLINE void populate_zone_cache(iso_alloc_zone_t *zone) {
 
 INTERNAL_HIDDEN ASSUME_ALIGNED void *_iso_calloc(size_t nmemb, size_t size) {
     unsigned int res;
+
+    if((is_pow2(size)) != true) {
+        size = next_pow2(size);
+    }
+
     size_t sz = nmemb * size;
 
-    if(__builtin_umul_overflow(nmemb, size, &res)) {
+    if(UNLIKELY(__builtin_umul_overflow(nmemb, size, &res))) {
         LOG_AND_ABORT("Call to calloc() will overflow nmemb=%zu size=%zu", nmemb, size);
         return NULL;
     }
@@ -1039,8 +1050,8 @@ INTERNAL_HIDDEN ASSUME_ALIGNED void *_iso_alloc(iso_alloc_zone_t *zone, size_t s
     }
 #endif
 
-    if(IS_ALIGNED(size) != 0) {
-        size = ALIGN_SZ_UP(size);
+    if((is_pow2(size)) != true) {
+        size = next_pow2(size);
     }
 
     if(UNLIKELY(zone && size > zone->chunk_size)) {
@@ -1071,15 +1082,10 @@ INTERNAL_HIDDEN ASSUME_ALIGNED void *_iso_alloc(iso_alloc_zone_t *zone, size_t s
 #if ALLOC_SANITY
     /* We don't sample if we are allocating from a private zone */
     if(zone != NULL) {
-        /* We only sample allocations smaller than an individual
-         * page. We are unlikely to find uninitialized reads on
-         * larger size and it makes tracking them less complex */
-        const size_t sampled_size = ALIGN_SZ_UP(size);
-
-        if(sampled_size < g_page_size && _sane_sampled < MAX_SANE_SAMPLES) {
+        if(size < g_page_size && _sane_sampled < MAX_SANE_SAMPLES) {
             /* If we chose to sample this allocation then
              * _iso_alloc_sample will call UNLOCK_ROOT() */
-            void *ps = _iso_alloc_sample(sampled_size);
+            void *ps = _iso_alloc_sample(size);
 
             if(ps != NULL) {
                 return ps;


### PR DESCRIPTION
* Add `STRONG_SIZE_ISOLATION`. I opted not to name this strict because the allocator will not create a zone exactly for the size requested if one doesn't exist. The reason we cannot do that is because in any real program (even after aligning the request size to 8 bytes) we will quickly run out of memory as each zone is 4mb in size.
* `is_zone_usable` still allows a larger zone to satisfy a smaller allocation request up to 1024 bytes. Without this we would likely run out of memory quickly, see first bullet.
* `STRONG_SIZE_ISOLATION` is off by default, which means by default IsoAlloc will look for `next_pow2(size)` up to 1024 in the zone lookup table until it finds a suitable zone.
* This PR also ensures that all allocations are powers of 2 and rounds them up as necessary.