### PR TITLE
add memset_sanity and build cleanups to enable it

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ When enabled, the `CPU_PIN` feature will restrict allocations from a given zone 
 * When destroying private zones if `NEVER_REUSE_ZONES` is enabled IsoAlloc won't attempt to repurpose the zone
 * Zones are retired and replaced after they've allocated and freed a specific number of chunks. This is calculated as `ZONE_ALLOC_RETIRE * max_chunk_count_for_zone`.
 * `MEMORY_TAGGING` When enabled IsoAlloc will create a 1 byte tag for each chunk in private zones. See the [MEMORY_TAGGING.md](MEMORY_TAGGING.md) documentation, or [this test](tests/tagged_ptr_test.cpp) for an example of how to use it.
-* `MEMCPY_SANITY` Configures the allocator will hook all calls to `memcpy` and check for out of bounds r/w operations when either src or dst points to a chunk allocated by IsoAlloc
+* `MEMCPY_SANITY` and `MEMSET_SANITY` Configures the allocator will hook all calls to `memcpy`/`memset` and check for out of bounds r/w operations when either src or dst points to a chunk allocated by IsoAlloc
 * `STRONG_SIZE_ISOLATION` Enables a policy that enforces stronger memory isolation by size
 
 ## Building
@@ -101,6 +101,8 @@ The Makefile targets are very simple:
 `make analyze_library_debug` - Builds the library with clang's scan-build if installed
 
 `make tests` - Builds and runs all tests
+
+`make libc_sanity_tests` - Builds the memcpy/memset libc hook sanity tests
 
 `make perf_tests` - Builds and runs a simple performance test that uses gprof. Linux only
 

--- a/include/iso_alloc_sanity.h
+++ b/include/iso_alloc_sanity.h
@@ -86,3 +86,8 @@ INTERNAL_HIDDEN _sane_allocation_t *_get_sane_alloc(void *p);
 INTERNAL_HIDDEN void *__iso_memcpy(void *restrict dest, const void *restrict src, size_t n);
 INTERNAL_HIDDEN void *_iso_alloc_memcpy(void *restrict dest, const void *restrict src, size_t n);
 #endif
+
+#if MEMSET_SANITY
+INTERNAL_HIDDEN void *__iso_memset(void *dest, int b, size_t n);
+INTERNAL_HIDDEN void *_iso_alloc_memset(void *dest, int b, size_t n);
+#endif

--- a/src/libc_hook.c
+++ b/src/libc_hook.c
@@ -5,9 +5,13 @@
 #include "iso_alloc_sanity.h"
 
 #if MEMCPY_SANITY
-
 EXTERNAL_API void *memcpy(void *restrict dest, const void *restrict src, size_t n) {
     return _iso_alloc_memcpy(dest, src, n);
 }
+#endif
 
+#if MEMSET_SANITY
+EXTERNAL_API void *memset(void *dest, int b, size_t n) {
+    return _iso_alloc_memset(dest, b, n);
+}
 #endif

--- a/tests/heap_underflow.c
+++ b/tests/heap_underflow.c
@@ -13,7 +13,18 @@ int main(int argc, char *argv[]) {
     }
 
     p = (uint8_t *) iso_alloc(32);
+
+#if MEMSET_SANITY
+    uint8_t *p_dest = p - 65535;
+    size_t n = 65535;
+
+    while(n--) {
+        *p_dest++ = 0;
+    }
+#else
     memset(p - 65535, 0x42, 65535);
+#endif
+
     iso_free(p);
     iso_verify_zones();
 

--- a/tests/memcpy_sanity.c
+++ b/tests/memcpy_sanity.c
@@ -1,30 +1,27 @@
-/* iso_alloc heap_overflow.c
+/* iso_alloc memcpy_sanity.c
  * Copyright 2022 - chris.rohlf@gmail.com */
 
 #include "iso_alloc.h"
 #include "iso_alloc_internal.h"
 
+#if !MEMCPY_SANITY
+#error "This test intended to be run with -DMEMCPY_SANITY=1"
+#endif
+
 int main(int argc, char *argv[]) {
     uint8_t *p = NULL;
 
     for(int32_t i = 0; i < 1024; i++) {
-        p = (uint8_t *) iso_alloc(32);
+        p = (uint8_t *) iso_alloc(8);
         iso_free(p);
     }
 
-    p = (uint8_t *) iso_alloc(32);
+    p = (uint8_t *) iso_alloc(8);
 
     const char *A = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                     "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                     "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-#if MEMCPY_SANITY
     memcpy(p, A, strlen(A));
-#else
-    size_t n = strlen(A);
-    while(n--) {
-        *p++ = *A++;
-    }
-#endif
 
     iso_free(p);
     iso_verify_zones();

--- a/tests/memset_sanity.c
+++ b/tests/memset_sanity.c
@@ -1,8 +1,12 @@
-/* iso_alloc heap_overflow.c
+/* iso_alloc memset_sanity.c
  * Copyright 2022 - chris.rohlf@gmail.com */
 
 #include "iso_alloc.h"
 #include "iso_alloc_internal.h"
+
+#if !MEMSET_SANITY
+#error "This test intended to be run with -DMEMSET_SANITY=1"
+#endif
 
 int main(int argc, char *argv[]) {
     uint8_t *p = NULL;
@@ -13,18 +17,7 @@ int main(int argc, char *argv[]) {
     }
 
     p = (uint8_t *) iso_alloc(32);
-
-    const char *A = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-#if MEMCPY_SANITY
-    memcpy(p, A, strlen(A));
-#else
-    size_t n = strlen(A);
-    while(n--) {
-        *p++ = *A++;
-    }
-#endif
+    memset(p, 0x41, 65535);
 
     iso_free(p);
     iso_verify_zones();


### PR DESCRIPTION
This PR introduces `memset_sanity` as first proposed in #114 by @devnexen.
Updates the documentation for `make libc_sanity_tests`