### PR TITLE
cleanups, fix bug related to private to internal zone reuse, new test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,8 @@ tests: clean library_debug_unit_tests
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/zero_alloc.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/zero_alloc $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/uninit_read.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/uninit_read $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/sized_free.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/sized_free $(LDFLAGS)
+	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/pool_test.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/pool_test $(LDFLAGS)
+
 	utils/run_tests.sh
 
 init_test: clean library_debug_unit_tests
@@ -363,9 +365,9 @@ ifeq ($(MEMSET_SANITY), -DMEMSET_SANITY=1)
 endif
 	$(CC) $(CFLAGS) $(C_SRCS) $(OPTIMIZE) $(EXE_CFLAGS) $(OS_FLAGS) tests/tests.c -o $(BUILD_DIR)/tests
 	$(CC) $(CFLAGS) $(OPTIMIZE) $(EXE_CFLAGS) $(OS_FLAGS) -DMALLOC_PERF_TEST $(ISO_ALLOC_PRINTF_SRC) tests/tests.c -o $(BUILD_DIR)/malloc_tests
-	echo "Running IsoAlloc Performance Test"
+	@echo "Running IsoAlloc Performance Test"
 	build/tests
-	echo "Running system malloc Performance Test"
+	@echo "Running system malloc Performance Test"
 	build/malloc_tests
 
 ## C++ Support - Build a debug version of the unit test

--- a/README.md
+++ b/README.md
@@ -201,9 +201,11 @@ If all else fails please file an issue on the [github project](https://github.co
 
 `void iso_verify_zone(iso_alloc_zone_handle *zone)` - Verifies the state of specified zone. Will abort if inconsistencies are found.
 
-`int32_t iso_alloc_name_zone(iso_alloc_zone_handle *zone, char *name)` - Allows naming of private zones via prctl on Android
+`int32_t iso_alloc_name_zone(iso_alloc_zone_handle *zone, char *name)` - Allows naming of private zones via prctl on Android.
 
-`void iso_flush_caches()` - Flushes all thread specific caches. Intended to be used upon thread destruction
+`void iso_flush_caches()` - Flushes all thread specific caches. Intended to be used upon thread destruction.
+
+`size_t iso_zone_chunk_count(iso_alloc_zone_handle *zone)` - Returns the total number of chunks a private zone can hold not including canary chunks. If canaries are disabled this number is absolute, otherwise it is a safe lower bound and actual number may be higher due to canary creation random seed.
 
 ### Experimental APIs
 

--- a/include/iso_alloc.h
+++ b/include/iso_alloc.h
@@ -60,6 +60,7 @@ EXTERNAL_API NO_DISCARD MALLOC_ATTR void *iso_alloc_from_zone_tagged(iso_alloc_z
 EXTERNAL_API NO_DISCARD void *iso_alloc_tag_ptr(void *p, iso_alloc_zone_handle *zone);
 EXTERNAL_API NO_DISCARD void *iso_alloc_untag_ptr(void *p, iso_alloc_zone_handle *zone);
 EXTERNAL_API NO_DISCARD iso_alloc_zone_handle *iso_alloc_new_zone(size_t size);
+EXTERNAL_API NO_DISCARD size_t iso_zone_chunk_count(iso_alloc_zone_handle *zone);
 EXTERNAL_API void iso_alloc_destroy_zone(iso_alloc_zone_handle *zone);
 EXTERNAL_API void iso_alloc_protect_root();
 EXTERNAL_API void iso_alloc_unprotect_root();

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -394,6 +394,7 @@ INTERNAL_HIDDEN uint8_t _iso_alloc_get_mem_tag(void *p, iso_alloc_zone_t *zone);
 INTERNAL_HIDDEN size_t _iso_alloc_print_stats();
 INTERNAL_HIDDEN size_t _iso_chunk_size(void *p);
 INTERNAL_HIDDEN int64_t check_canary_no_abort(iso_alloc_zone_t *zone, const void *p);
+INTERNAL_HIDDEN void fixup_next_sz_index(iso_alloc_zone_t *zone, int32_t index);
 INTERNAL_HIDDEN void _iso_alloc_initialize(void);
 INTERNAL_HIDDEN void _iso_alloc_destroy(void);
 

--- a/src/iso_alloc_interfaces.c
+++ b/src/iso_alloc_interfaces.c
@@ -52,6 +52,17 @@ EXTERNAL_API size_t iso_chunksz(void *p) {
     return _iso_chunk_size(p);
 }
 
+EXTERNAL_API NO_DISCARD size_t iso_zone_chunk_count(iso_alloc_zone_handle *zone) {
+    UNMASK_ZONE_HANDLE(zone);
+    iso_alloc_zone_t *_zone = (iso_alloc_zone_t *) zone;
+    size_t canaries = 0;
+
+#if !DISABLE_CANARY
+    canaries = _zone->chunk_count >> CANARY_COUNT_DIV;
+#endif
+    return (_zone->chunk_count - canaries);
+}
+
 EXTERNAL_API NO_DISCARD REALLOC_SIZE ASSUME_ALIGNED void *iso_realloc(void *p, size_t size) {
     if(size == 0) {
         iso_free(p);

--- a/src/iso_alloc_profiler.c
+++ b/src/iso_alloc_profiler.c
@@ -108,7 +108,7 @@ INTERNAL_HIDDEN uint64_t _iso_alloc_detect_leaks() {
  * a root like a GC, so if you purposefully did not free a
  * chunk then expect it to show up as leaked! */
 INTERNAL_HIDDEN uint64_t _iso_alloc_zone_leak_detector(iso_alloc_zone_t *zone, bool profile) {
-    uint64_t in_use = 0;
+    uint32_t in_use = 0;
 
 #if LEAK_DETECTOR || HEAP_PROFILER
     if(zone == NULL) {
@@ -118,7 +118,7 @@ INTERNAL_HIDDEN uint64_t _iso_alloc_zone_leak_detector(iso_alloc_zone_t *zone, b
     UNMASK_ZONE_PTRS(zone);
 
     bitmap_index_t *bm = (bitmap_index_t *) zone->bitmap_start;
-    int64_t was_used = 0;
+    uint32_t was_used = 0;
 
     for(int64_t i = 0; i < zone->bitmap_size / sizeof(bitmap_index_t); i++) {
         for(size_t j = 0; j < BITS_PER_QWORD; j += BITS_PER_CHUNK) {
@@ -158,8 +158,8 @@ INTERNAL_HIDDEN uint64_t _iso_alloc_zone_leak_detector(iso_alloc_zone_t *zone, b
     }
 
     if(profile == false) {
-        LOG("Zone[%d] Total number of %d byte chunks(%d) used and free'd (%lu) (%d percent) (%d)", zone->index, zone->chunk_size, zone->chunk_count,
-            was_used, (int32_t) ((float) was_used / zone->chunk_count) * 100.0, zone->bitmap_size);
+        LOG("Zone[%d] Total number of %d byte chunks(%d) used and free'd (%d) (%d percent), in use (%d)", zone->index, zone->chunk_size, zone->chunk_count,
+            was_used, (int32_t) ((float) was_used / zone->chunk_count) * 100.0, in_use);
     }
 
     MASK_ZONE_PTRS(zone);

--- a/tests/pool_test.c
+++ b/tests/pool_test.c
@@ -1,0 +1,50 @@
+/* iso_alloc pool_test.c
+ * Copyright 2022 - chris.rohlf@gmail.com */
+
+#include "iso_alloc.h"
+#include "iso_alloc_internal.h"
+
+uint32_t allocation_sizes[] = {ZONE_16, ZONE_32, ZONE_64, ZONE_128,
+                               ZONE_256, ZONE_512, ZONE_1024,
+                               ZONE_2048, ZONE_4096, ZONE_8192};
+
+uint32_t array_sizes[] = {16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192};
+
+int allocate(size_t array_size, size_t allocation_size) {
+    iso_alloc_zone_handle *zone = iso_alloc_new_zone(allocation_size);
+    size_t total_chunks = iso_zone_chunk_count(zone);
+    int32_t alloc_count = 0;
+
+    /* We can treat private zones like pools of chunks
+     * that don't need to be freed. Instead we can just
+     * destroy the whole zone when we are done. We get
+     * the benefits of pools with all of the security
+     * properties of an IsoAlloc zone */
+    for(int i = 0; i < total_chunks; i++) {
+        void *p = iso_alloc_from_zone(zone);
+
+        if(p == NULL) {
+            LOG_AND_ABORT("Failed to allocate %ld bytes after %d total allocations from zone with %d total chunks", allocation_size, alloc_count, total_chunks);
+        }
+
+        alloc_count++;
+    }
+
+    iso_alloc_destroy_zone(zone);
+
+    return OK;
+}
+
+int main(int argc, char *argv[]) {
+    for(int i = 0; i < sizeof(array_sizes) / sizeof(uint32_t); i++) {
+        for(int z = 0; z < sizeof(allocation_sizes) / sizeof(uint32_t); z++) {
+            allocate(array_sizes[i], allocation_sizes[z]);
+        }
+    }
+
+    for(int i = 0; i < sizeof(array_sizes) / sizeof(uint32_t); i++) {
+        allocate(array_sizes[i], 0);
+    }
+
+    return 0;
+}

--- a/utils/run_tests.sh
+++ b/utils/run_tests.sh
@@ -3,7 +3,7 @@
 # examples of code that should crash
 $(echo '' > test_output.txt)
 
-tests=("tests" "big_tests" "interfaces_test" "thread_tests" "tagged_ptr_test")
+tests=("tests" "big_tests" "interfaces_test" "thread_tests" "tagged_ptr_test" "pool_test")
 failure=0
 succeeded=0
 


### PR DESCRIPTION
* Add a new test showing how to use private zones as 'pools' you alloc from but never free and instead just destroy
* Fix a bug related to next_sz_index when a private zone is destroyed and becomes internally managed
* Minor cleanups to code and documentation