### PR TITLE
Bugfixes 9 2022

### DIFF
--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -672,14 +672,12 @@ INTERNAL_HIDDEN void fill_free_bit_slot_cache(iso_alloc_zone_t *zone) {
      * start searching but may mean we end up with a smaller
      * cache. This may negatively affect performance but
      * leads to a less predictable free list */
-    bitmap_index_t bm_idx;
+    bitmap_index_t bm_idx = 0;
 
     /* The largest zone->max_bitmap_idx we will ever
      * have is 8192 for SMALLEST_CHUNK_SZ (16) */
     if(zone->max_bitmap_idx > ALIGNMENT) {
-        bm_idx = ((uint32_t) rand_uint64() * (zone->max_bitmap_idx - 1) >> 32);
-    } else {
-        bm_idx = 0;
+        bm_idx = ((uint32_t) rand_uint64() & (zone->max_bitmap_idx - 1));
     }
 
     __iso_memset(zone->free_bit_slot_cache, BAD_BIT_SLOT, sizeof(zone->free_bit_slot_cache));

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -619,7 +619,7 @@ INTERNAL_HIDDEN iso_alloc_zone_t *_iso_new_zone(size_t size, bool internal, int3
     return new_zone;
 }
 
-/* Fixes the next_sz_index list for a given zone */
+/* Appends a zone to the next_sz_index list for the size it manages */
 INTERNAL_HIDDEN void fixup_next_sz_index(iso_alloc_zone_t *zone, int32_t index) {
     _root->chunk_lookup_table[ADDR_TO_CHUNK_TABLE(zone->user_pages_start)] = zone->index;
     const size_t chunk_size = zone->chunk_size;

--- a/tests/alloc_fuzz.c
+++ b/tests/alloc_fuzz.c
@@ -9,13 +9,13 @@
 #include "iso_alloc_internal.h"
 #include <time.h>
 
-uint32_t allocation_sizes[] = {ZONE_16, ZONE_32, ZONE_64, ZONE_128,
-                               ZONE_256, ZONE_512, ZONE_1024,
-                               ZONE_2048, ZONE_4096, ZONE_8192,
-                               SMALL_SZ_MAX / 4, SMALL_SZ_MAX / 2,
-                               SMALL_SZ_MAX - 1, SMALL_SZ_MAX};
+static const uint32_t allocation_sizes[] = {ZONE_16, ZONE_32, ZONE_64, ZONE_128,
+                                            ZONE_256, ZONE_512, ZONE_1024,
+                                            ZONE_2048, ZONE_4096, ZONE_8192,
+                                            SMALL_SZ_MAX / 4, SMALL_SZ_MAX / 2,
+                                            SMALL_SZ_MAX - 1, SMALL_SZ_MAX};
 
-uint32_t array_sizes[] = {16, 32, 64, 128, 256, 512, 1024, 2048};
+static const uint32_t array_sizes[] = {16, 32, 64, 128, 256, 512, 1024, 2048};
 
 /* Parameters for controlling probability of leaking a chunk.
  * This will add up very quickly with the speed of allocations.

--- a/tests/pool_test.c
+++ b/tests/pool_test.c
@@ -4,11 +4,11 @@
 #include "iso_alloc.h"
 #include "iso_alloc_internal.h"
 
-uint32_t allocation_sizes[] = {ZONE_16, ZONE_32, ZONE_64, ZONE_128,
-                               ZONE_256, ZONE_512, ZONE_1024,
-                               ZONE_2048, ZONE_4096, ZONE_8192};
+static const uint32_t allocation_sizes[] = {ZONE_16, ZONE_32, ZONE_64, ZONE_128,
+                                            ZONE_256, ZONE_512, ZONE_1024,
+                                            ZONE_2048, ZONE_4096, ZONE_8192};
 
-uint32_t array_sizes[] = {16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192};
+static const uint32_t array_sizes[] = {16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192};
 
 int allocate(size_t array_size, size_t allocation_size) {
     iso_alloc_zone_handle *zone = iso_alloc_new_zone(allocation_size);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -5,12 +5,12 @@
 #include "iso_alloc_internal.h"
 #include <time.h>
 
-uint32_t allocation_sizes[] = {ZONE_16, ZONE_32, ZONE_64, ZONE_128,
-                               ZONE_256, ZONE_512, ZONE_1024,
-                               ZONE_2048, ZONE_4096, ZONE_8192};
+static const uint32_t allocation_sizes[] = {ZONE_16, ZONE_32, ZONE_64, ZONE_128,
+                                            ZONE_256, ZONE_512, ZONE_1024,
+                                            ZONE_2048, ZONE_4096, ZONE_8192};
 
-uint32_t array_sizes[] = {16, 32, 64, 128, 256, 512, 1024,
-                          2048, 4096, 8192, 16384, 32768, 65536};
+static const uint32_t array_sizes[] = {16, 32, 64, 128, 256, 512, 1024,
+                                       2048, 4096, 8192, 16384, 32768, 65536};
 
 int32_t alloc_count;
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -7,12 +7,12 @@
 
 using namespace std;
 
-uint32_t allocation_sizes[] = {ZONE_16, ZONE_32, ZONE_64, ZONE_128,
-                               ZONE_256, ZONE_512, ZONE_1024,
-                               ZONE_2048, ZONE_4096, ZONE_8192};
+static const uint32_t allocation_sizes[] = {ZONE_16, ZONE_32, ZONE_64, ZONE_128,
+                                            ZONE_256, ZONE_512, ZONE_1024,
+                                            ZONE_2048, ZONE_4096, ZONE_8192};
 
-uint32_t array_sizes[] = {16, 32, 64, 128, 256, 512, 1024,
-                          2048, 4096, 8192, 16384, 32768, 65536};
+static const uint32_t array_sizes[] = {16, 32, 64, 128, 256, 512, 1024,
+                                       2048, 4096, 8192, 16384, 32768, 65536};
 
 int32_t alloc_count;
 

--- a/tests/thread_tests.c
+++ b/tests/thread_tests.c
@@ -4,11 +4,11 @@
 #include "iso_alloc.h"
 #include "iso_alloc_internal.h"
 
-uint32_t allocation_sizes[] = {ZONE_16, ZONE_32, ZONE_64, ZONE_128,
-                               ZONE_256, ZONE_512, ZONE_1024,
-                               ZONE_2048, ZONE_4096, ZONE_8192};
+static const uint32_t allocation_sizes[] = {ZONE_16, ZONE_32, ZONE_64, ZONE_128,
+                                            ZONE_256, ZONE_512, ZONE_1024,
+                                            ZONE_2048, ZONE_4096, ZONE_8192};
 
-uint32_t array_sizes[] = {16, 32, 256, 512, 1024, 2048, 8192, 16384};
+static const uint32_t array_sizes[] = {16, 32, 256, 512, 1024, 2048, 8192, 16384};
 
 /* This test can be repurposed for benchmarking
  * against other allocators using LD_PRELOAD */


### PR DESCRIPTION
* Fix an important bug that somehow slipped in during a prior copy/paste that resulted in our free list cache always starting at index 0 of the bitmap. It now searches at a random index within the bitmap again.
* This fixes a few variables in tests to be `static const`