### PR TITLE
remove NEVER_REUSE_ZONES, perf fixes with zone lookup table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ CXX = clang++
 ## PERM_FREE_REALLOC - Permanently free any realloc'd chunk
 ## DISABLE_CANARY - Disables the use of canaries, improves performance
 ## NEVER_REUSE_ZONES - Tells IsoAlloc to unmap user and bitmap pages when destroying private zones
-SECURITY_FLAGS = -DSANITIZE_CHUNKS=0 -DFUZZ_MODE=0 -DPERM_FREE_REALLOC=0 -DDISABLE_CANARY=0	\
-                 -DNEVER_REUSE_ZONES=0
+SECURITY_FLAGS = -DSANITIZE_CHUNKS=0 -DFUZZ_MODE=0 -DPERM_FREE_REALLOC=0 -DDISABLE_CANARY=0
 
 ## Enable memory tagging support. This will generate a random
 ## 1 byte tag per addressable chunk of memory. These tags can

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -59,7 +59,7 @@ This thread local cache speeds up the free hot path by quarantining chunks until
 
 ### Zone Lookup Table
 
-Zones are linked by their `next_sz_index` member which tells the allocator where in the `_root->zones` array it can find the next zone that holds the same size chunks. This lookup table helps us find the first zone that holds a specific size in O(1) time. This is achieved by placing a zone's index value at that zones size index in the table, e.g. `zone_lookup_table[zone->size] = zone->index`, from there we just need to use the next zone's index member and walk it like a singly linked list to find other zones of that size.
+Zones are linked by their `next_sz_index` member which tells the allocator where in the `_root->zones` array it can find the next zone that holds the same size chunks. This lookup table helps us find the first zone that holds a specific size in O(1) time. This is achieved by placing a zone's index value at that zones size index in the table, e.g. `zone_lookup_table[zone->size] = zone->index`, from there we just need to use the next zone's index member and walk it like a singly linked list to find other zones of that size. Zones are added to the front of the list as they are created.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ When enabled, the `CPU_PIN` feature will restrict allocations from a given zone 
 * By default `NO_ZERO_ALLOCATIONS` will return a pointer to a page marked `PROT_NONE` for all `0` sized allocations.
 * When `ABORT_NO_ENTROPY` is enabled IsoAlloc will abort when it can't gather enough entropy.
 * When `SHUFFLE_BIT_SLOT_CACHE` is enabled IsoAlloc will shuffle the bit slot cache upon creation (3-4x perf hit)
-* When destroying private zones if `NEVER_REUSE_ZONES` is enabled IsoAlloc won't attempt to repurpose the zone
 * Zones are retired and replaced after they've allocated and freed a specific number of chunks. This is calculated as `ZONE_ALLOC_RETIRE * max_chunk_count_for_zone`.
 * `MEMORY_TAGGING` When enabled IsoAlloc will create a 1 byte tag for each chunk in private zones. See the [MEMORY_TAGGING.md](MEMORY_TAGGING.md) documentation, or [this test](tests/tagged_ptr_test.cpp) for an example of how to use it.
 * `MEMCPY_SANITY` and `MEMSET_SANITY` Configures the allocator will hook all calls to `memcpy`/`memset` and check for out of bounds r/w operations when either src or dst points to a chunk allocated by IsoAlloc

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -372,7 +372,6 @@ INTERNAL_HIDDEN void iso_free_big_zone(iso_alloc_big_zone_t *big_zone, bool perm
 INTERNAL_HIDDEN void _iso_alloc_protect_root(void);
 INTERNAL_HIDDEN void _iso_free_quarantine(void *p);
 INTERNAL_HIDDEN void _iso_alloc_unprotect_root(void);
-INTERNAL_HIDDEN void _unmap_zone(iso_alloc_zone_t *zone);
 INTERNAL_HIDDEN void *_tag_ptr(void *p, iso_alloc_zone_t *zone);
 INTERNAL_HIDDEN void *_untag_ptr(void *p, iso_alloc_zone_t *zone);
 INTERNAL_HIDDEN ASSUME_ALIGNED void *_iso_big_alloc(size_t size);
@@ -394,7 +393,6 @@ INTERNAL_HIDDEN uint8_t _iso_alloc_get_mem_tag(void *p, iso_alloc_zone_t *zone);
 INTERNAL_HIDDEN size_t _iso_alloc_print_stats();
 INTERNAL_HIDDEN size_t _iso_chunk_size(void *p);
 INTERNAL_HIDDEN int64_t check_canary_no_abort(iso_alloc_zone_t *zone, const void *p);
-INTERNAL_HIDDEN void fixup_next_sz_index(iso_alloc_zone_t *zone, int32_t index);
 INTERNAL_HIDDEN void _iso_alloc_initialize(void);
 INTERNAL_HIDDEN void _iso_alloc_destroy(void);
 

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -582,16 +582,14 @@ INTERNAL_HIDDEN iso_alloc_zone_t *_iso_new_zone(size_t size, bool internal, int3
         if(_root->zone_lookup_table[size] == 0) {
             _root->zone_lookup_table[size] = new_zone->index;
             new_zone->next_sz_index = 0;
-        } else {
+        } else if(index < 0) {
             /* If the index is < 0 then this is a brand new zone and
              * not a replacement which means we need to add it to the
              * zone_lookup_table. We prepend it to the start of the
              * list ensuring it is checked first on alloc path */
-            if(index < 0) {
-                int32_t current_idx = _root->zone_lookup_table[size];
-                _root->zone_lookup_table[size] = new_zone->index;
-                new_zone->next_sz_index = current_idx;
-            }
+            int32_t current_idx = _root->zone_lookup_table[size];
+            _root->zone_lookup_table[size] = new_zone->index;
+            new_zone->next_sz_index = current_idx;
         }
     }
 

--- a/src/iso_alloc_mem_tags.c
+++ b/src/iso_alloc_mem_tags.c
@@ -57,8 +57,9 @@ INTERNAL_HIDDEN bool _refresh_zone_mem_tags(iso_alloc_zone_t *zone) {
     if(UNLIKELY(zone->af_count == 0 && zone->alloc_count > (zone->chunk_count << _root->zone_retirement_shf)) >> 2) {
         size_t s = ROUND_UP_PAGE(zone->chunk_count * MEM_TAG_SIZE);
         uint64_t *_mtp = (zone->user_pages_start - g_page_size - s);
+        size_t tms = s / sizeof(uint64_t);
 
-        for(uint64_t o = 0; o > s / sizeof(uint64_t); o++) {
+        for(uint64_t o = 0; o > tms; o++) {
             _mtp[o] = rand_uint64();
         }
 

--- a/src/iso_alloc_profiler.c
+++ b/src/iso_alloc_profiler.c
@@ -159,7 +159,7 @@ INTERNAL_HIDDEN uint64_t _iso_alloc_zone_leak_detector(iso_alloc_zone_t *zone, b
     }
 
     if(profile == false) {
-        LOG("Zone[%d] Total number of %d byte chunks(%d) used and free'd (%d) (%d percent), in use (%d)", zone->index, zone->chunk_size, zone->chunk_count,
+        LOG("Zone[%d] Total number of %d byte chunks(%d) used and free'd (%d) (%d percent), in use = %d", zone->index, zone->chunk_size, zone->chunk_count,
             was_used, (int32_t) ((float) was_used / zone->chunk_count) * 100, in_use);
     }
 
@@ -194,7 +194,7 @@ INTERNAL_HIDDEN uint64_t __iso_alloc_mem_usage() {
         iso_alloc_zone_t *zone = &_root->zones[i];
         mem_usage += zone->bitmap_size;
         mem_usage += ZONE_USER_SIZE;
-        LOG("Zone[%d] holds %d byte chunks, megabytes (%d) next zone = %d, total allocations = %d, in use %d", zone->index, zone->chunk_size,
+        LOG("Zone[%d] holds %d byte chunks, megabytes (%d) next zone = %d, total allocations = %d, in use = %d", zone->index, zone->chunk_size,
             (ZONE_USER_SIZE / MEGABYTE_SIZE), zone->next_sz_index, zone->alloc_count, zone->af_count);
     }
 


### PR DESCRIPTION
* Remove `NEVER_REUSE_ZONES` option as the behavior is basically default now. Every time we retire an internally manage zone or destroy a private one we do the same thing, unmap the pages and create a new zone in its place
* Optimize the zone lookup table by inserting new zones into the front of a next_sz_index list and not the back. This ensures the allocation path finds the newest zones first and allows for faster insertion in the list.
* Minor perf fixes in memory tagging etc loops
* Documentation update