### PR TITLE
Move more globals into _root

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -16,6 +16,8 @@ Contributing to IsoAlloc is a pretty standard process of forking the repo, makin
 
 `make cpp_library` - Build a release version of the library with C++ support
 
+Repeat the steps above using gcc/g++ as your compiler. e.g. `make tests CC=gcc CXX=g++`
+
 Compile a debug version of the library with `make cpp_library_debug` and then run a basic test using `LD_PRELOAD` and another binary.
 
 If you're making changes that are handled differently between Clang and GCC then please run the tests above but also set the `CC` and `CXX` environment variables approriately.

--- a/Makefile
+++ b/Makefile
@@ -374,8 +374,8 @@ cpp_tests: clean cpp_library_debug
 	@echo "make cpp_tests"
 	$(CXX) $(CXXFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(EXE_CFLAGS) $(OS_FLAGS) tests/tests.cpp $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/cxx_tests $(LDFLAGS)
 	$(CXX) $(CXXFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(EXE_CFLAGS) $(OS_FLAGS) tests/tagged_ptr_test.cpp $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/tagged_ptr_test $(LDFLAGS)
-	LD_LIBRARY_PATH=$(BUILD_DIR)/ LD_PRELOAD=$(BUILD_DIR)/$(LIBNAME) $(BUILD_DIR)/cxx_tests
-	LD_LIBRARY_PATH=$(BUILD_DIR)/ LD_PRELOAD=$(BUILD_DIR)/$(LIBNAME) $(BUILD_DIR)/tagged_ptr_test
+	LD_LIBRARY_PATH=$(BUILD_DIR)/ $(BUILD_DIR)/cxx_tests
+	LD_LIBRARY_PATH=$(BUILD_DIR)/ $(BUILD_DIR)/tagged_ptr_test
 
 install:
 	cp -pR build/$(LIBNAME) /usr/lib/

--- a/include/iso_alloc_ds.h
+++ b/include/iso_alloc_ds.h
@@ -89,10 +89,8 @@ typedef struct {
     size_t zones_size;
 #if THREAD_SUPPORT
 #if USE_SPINLOCK
-    atomic_flag root_busy_flag;
     atomic_flag big_zone_busy_flag;
 #else
-    pthread_mutex_t root_busy_mutex;
     pthread_mutex_t big_zone_busy_mutex;
 #endif
 #endif

--- a/include/iso_alloc_ds.h
+++ b/include/iso_alloc_ds.h
@@ -87,6 +87,18 @@ typedef struct {
     iso_alloc_big_zone_t *big_zone_head;
     iso_alloc_zone_t *zones;
     size_t zones_size;
+#if THREAD_SUPPORT
+#if USE_SPINLOCK
+    atomic_flag root_busy_flag;
+    atomic_flag big_zone_busy_flag;
+#else
+    pthread_mutex_t root_busy_mutex;
+    pthread_mutex_t big_zone_busy_mutex;
+#endif
+#endif
+#if NO_ZERO_ALLOCATIONS
+    void *zero_alloc_page;
+#endif
 } __attribute__((aligned(sizeof(int64_t)))) iso_alloc_root;
 
 typedef struct {

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -284,12 +284,13 @@ extern uint32_t g_page_size_shift;
 
 #if THREAD_SUPPORT
 #if USE_SPINLOCK
+extern atomic_flag root_busy_flag;
 #define LOCK_ROOT() \
     do {            \
-    } while(atomic_flag_test_and_set(&_root->root_busy_flag));
+    } while(atomic_flag_test_and_set(&root_busy_flag));
 
 #define UNLOCK_ROOT() \
-    atomic_flag_clear(&_root->root_busy_flag);
+    atomic_flag_clear(&root_busy_flag);
 
 #define LOCK_BIG_ZONE() \
     do {                \
@@ -298,11 +299,12 @@ extern uint32_t g_page_size_shift;
 #define UNLOCK_BIG_ZONE() \
     atomic_flag_clear(&_root->big_zone_busy_flag);
 #else
+extern pthread_mutex_t root_busy_mutex;
 #define LOCK_ROOT() \
-    pthread_mutex_lock(&_root->root_busy_mutex);
+    pthread_mutex_lock(&root_busy_mutex);
 
 #define UNLOCK_ROOT() \
-    pthread_mutex_unlock(&_root->root_busy_mutex);
+    pthread_mutex_unlock(&root_busy_mutex);
 
 #define LOCK_BIG_ZONE() \
     pthread_mutex_lock(&_root->big_zone_busy_mutex);

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -41,13 +41,6 @@ assert(sizeof(size_t) >= 64)
 #include <sys/mman.h>
 #include <sys/types.h>
 
-#include "iso_alloc.h"
-#include "iso_alloc_sanity.h"
-#include "iso_alloc_util.h"
-#include "iso_alloc_ds.h"
-#include "compiler.h"
-#include "conf.h"
-
 #if MEM_USAGE
 #include <sys/resource.h>
 #endif
@@ -65,6 +58,13 @@ assert(sizeof(size_t) >= 64)
 #if HEAP_PROFILER
 #include <fcntl.h>
 #endif
+
+#include "iso_alloc.h"
+#include "iso_alloc_sanity.h"
+#include "iso_alloc_util.h"
+#include "iso_alloc_ds.h"
+#include "compiler.h"
+#include "conf.h"
 
 #ifndef MADV_DONTNEED
 #define MADV_DONTNEED POSIX_MADV_DONTNEED
@@ -284,37 +284,31 @@ extern uint32_t g_page_size_shift;
 
 #if THREAD_SUPPORT
 #if USE_SPINLOCK
-extern atomic_flag root_busy_flag;
-extern atomic_flag big_zone_busy_flag;
-
 #define LOCK_ROOT() \
     do {            \
-    } while(atomic_flag_test_and_set(&root_busy_flag));
+    } while(atomic_flag_test_and_set(&_root->root_busy_flag));
 
 #define UNLOCK_ROOT() \
-    atomic_flag_clear(&root_busy_flag);
+    atomic_flag_clear(&_root->root_busy_flag);
 
 #define LOCK_BIG_ZONE() \
     do {                \
-    } while(atomic_flag_test_and_set(&big_zone_busy_flag));
+    } while(atomic_flag_test_and_set(&_root->big_zone_busy_flag));
 
 #define UNLOCK_BIG_ZONE() \
-    atomic_flag_clear(&big_zone_busy_flag);
+    atomic_flag_clear(&_root->big_zone_busy_flag);
 #else
-extern pthread_mutex_t root_busy_mutex;
-extern pthread_mutex_t big_zone_busy_mutex;
-
 #define LOCK_ROOT() \
-    pthread_mutex_lock(&root_busy_mutex);
+    pthread_mutex_lock(&_root->root_busy_mutex);
 
 #define UNLOCK_ROOT() \
-    pthread_mutex_unlock(&root_busy_mutex);
+    pthread_mutex_unlock(&_root->root_busy_mutex);
 
 #define LOCK_BIG_ZONE() \
-    pthread_mutex_lock(&big_zone_busy_mutex);
+    pthread_mutex_lock(&_root->big_zone_busy_mutex);
 
 #define UNLOCK_BIG_ZONE() \
-    pthread_mutex_unlock(&big_zone_busy_mutex);
+    pthread_mutex_unlock(&_root->big_zone_busy_mutex);
 #endif
 #else
 #define LOCK_ROOT()

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -970,9 +970,10 @@ INTERNAL_HIDDEN ASSUME_ALIGNED void *_iso_alloc_bitslot_from_zone(bit_slot_t bit
 /* Does not require the root is locked */
 INTERNAL_HIDDEN INLINE void populate_zone_cache(iso_alloc_zone_t *zone) {
     _tzc *tzc = zone_cache;
+    size_t _zone_cache_count = zone_cache_count;
 
     /* Don't cache this zone if it was recently cached */
-    if(zone_cache_count != 0 && tzc[zone_cache_count - 1].zone == zone) {
+    if(_zone_cache_count != 0 && tzc[_zone_cache_count - 1].zone == zone) {
         return;
     }
 
@@ -980,15 +981,17 @@ INTERNAL_HIDDEN INLINE void populate_zone_cache(iso_alloc_zone_t *zone) {
         return;
     }
 
-    if(zone_cache_count < ZONE_CACHE_SZ) {
-        tzc[zone_cache_count].zone = zone;
-        tzc[zone_cache_count].chunk_size = zone->chunk_size;
-        zone_cache_count++;
+    if(_zone_cache_count < ZONE_CACHE_SZ) {
+        tzc[_zone_cache_count].zone = zone;
+        tzc[_zone_cache_count].chunk_size = zone->chunk_size;
+        _zone_cache_count++;
     } else {
-        zone_cache_count = 0;
-        tzc[zone_cache_count].zone = zone;
-        tzc[zone_cache_count].chunk_size = zone->chunk_size;
+        _zone_cache_count = 0;
+        tzc[_zone_cache_count].zone = zone;
+        tzc[_zone_cache_count].chunk_size = zone->chunk_size;
     }
+
+    zone_cache_count = _zone_cache_count;
 }
 
 INTERNAL_HIDDEN ASSUME_ALIGNED void *_iso_calloc(size_t nmemb, size_t size) {

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -9,6 +9,12 @@
 #endif
 
 #if THREAD_SUPPORT
+
+#if USE_SPINLOCK
+atomic_flag root_busy_flag;
+#else
+pthread_mutex_t root_busy_mutex;
+#endif
 /* We cannot initialize this on thread creation so
  * we can't mmap them somewhere with guard pages but
  * they are thread local storage so their location
@@ -227,7 +233,7 @@ INTERNAL_HIDDEN void _iso_alloc_initialize(void) {
     iso_alloc_initialize_global_root();
 
 #if THREAD_SUPPORT && !USE_SPINLOCK
-    pthread_mutex_init(&_root->root_busy_mutex, NULL);
+    pthread_mutex_init(&root_busy_mutex, NULL);
     pthread_mutex_init(&_root->big_zone_busy_mutex, NULL);
 #if ALLOC_SANITY
     pthread_mutex_init(&sane_cache_mutex, NULL);

--- a/utils/run_tests.sh
+++ b/utils/run_tests.sh
@@ -11,12 +11,6 @@ $(ulimit -c 0)
 
 export LD_LIBRARY_PATH=build/
 
-#if [[ $OSTYPE == 'darwin'* ]]; then
-#    export DYLD_INSERT_LIBRARIES=build/libisoalloc.dylib
-#else
-#    export LD_PRELOAD=build/libisoalloc.so
-#fi
-
 for t in "${tests[@]}"; do
     echo -n "Running $t test"
     echo "Running $t test" >> test_output.txt 2>&1

--- a/utils/run_tests.sh
+++ b/utils/run_tests.sh
@@ -11,11 +11,11 @@ $(ulimit -c 0)
 
 export LD_LIBRARY_PATH=build/
 
-if [[ $OSTYPE == 'darwin'* ]]; then
-    export DYLD_INSERT_LIBRARIES=build/libisoalloc.dylib
-else
-    export LD_PRELOAD=build/libisoalloc.so
-fi
+#if [[ $OSTYPE == 'darwin'* ]]; then
+#    export DYLD_INSERT_LIBRARIES=build/libisoalloc.dylib
+#else
+#    export LD_PRELOAD=build/libisoalloc.so
+#fi
 
 for t in "${tests[@]}"; do
     echo -n "Running $t test"


### PR DESCRIPTION
Continue moving globals we access from the hot path or in tight loops into _root for better cache locality and less implicit memcpy's of the data. This PR alone removed ~30 calls to memcpy.