### PR TITLE
Minor last minute cleanups before new version

### DIFF
--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -240,13 +240,11 @@ assert(sizeof(size_t) >= 64)
 #define BIG_ZONE_USER_PAGE_COUNT 2
 #define BIG_ZONE_USER_PAGE_COUNT_SHIFT 1
 
+#if MEMORY_TAGGING
 #define TAGGED_PTR_MASK 0x00ffffffffffffff
 #define IS_TAGGED_PTR_MASK 0xff00000000000000
 #define UNTAGGED_BITS 56
-
-/* A uint64_t of bitslots below this value will
- * have at least 1 single free bit slot */
-#define ALLOCATED_BITSLOTS 0x5555555555555555
+#endif
 
 #define MEGABYTE_SIZE 1048576
 #define KILOBYTE_SIZE 1024

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -1007,6 +1007,14 @@ INTERNAL_HIDDEN ASSUME_ALIGNED void *_iso_calloc(size_t nmemb, size_t size) {
 
     void *p = _iso_alloc(NULL, sz);
 
+#if NO_ZERO_ALLOCATIONS
+    /* Without this check we would immediately segfault in
+     * the call to __iso_memset() to zeroize the chunk */
+    if(UNLIKELY(sz == 0)) {
+        return p;
+    }
+#endif
+
     __iso_memset(p, 0x0, sz);
     return p;
 }


### PR DESCRIPTION
- Minor cleanup to memory tagging defines
- Don't `memset` calloc(0) chunks if `NO_ZERO_ALLOCATIONS` is enabled