### PR TITLE
Reduce syscalls, code cleanup

### DIFF
--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -1,19 +1,20 @@
 LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
-LOCAL_CFLAGS := -DTHREAD_SUPPORT=1 -pthread						\
+LOCAL_CFLAGS := -DTHREAD_SUPPORT=1 -pthread									\
 	-DPRE_POPULATE_PAGES=0 -DSMALL_MEM_STARTUP=0 -DSANITIZE_CHUNKS=0		\
 	-DFUZZ_MODE=0 -DPERM_FREE_REALLOC=0 -DDISABLE_CANARY=0 -Werror			\
 	-pedantic -Wno-pointer-arith -Wno-gnu-zero-variadic-macro-arguments		\
 	-Wno-format-pedantic -DMALLOC_HOOK=1 -fvisibility=hidden -std=c11		\
-	-DALLOC_SANITY=0 -DUNINIT_READ_SANITY=0 -DCPU_PIN=0 -DEXPERIMENTAL=0		\
+	-DALLOC_SANITY=0 -DUNINIT_READ_SANITY=0 -DCPU_PIN=0 -DEXPERIMENTAL=0	\
 	-DUAF_PTR_PAGE=0 -DVERIFY_FREE_BIT_SLOTS=0 -DNAMED_MAPPINGS=1 -fPIC		\
 	-shared -DDEBUG=1 -DLEAK_DETECTOR=1 -DMEM_USAGE=1 -DUSE_MLOCK=1 		\
-	-DMEMORY_TAGGING=0 -DSCHED_GETCPU -g -ggdb3 -fno-omit-frame-pointer
+	-DMEMORY_TAGGING=0 -DSCHED_GETCPU -g -ggdb3 -fno-omit-frame-pointer		\
+	-DRANDOMIZE_FREELIST=1
 
 LOCAL_SRC_FILES := ../../src/iso_alloc.c ../../src/iso_alloc_printf.c ../../src/iso_alloc_random.c				\
 				   ../../src/iso_alloc_search.c ../../src/iso_alloc_interfaces.c ../../src/iso_alloc_profiler.c	\
-				   ../../src/iso_alloc_sanity.c ../../src/iso_alloc_util.c ../../src/malloc_hook.c 		\
+				   ../../src/iso_alloc_sanity.c ../../src/iso_alloc_util.c ../../src/malloc_hook.c 				\
 				   ../../src/libc_hook.c ../../src/iso_alloc_mem_tags.c
 
 LOCAL_C_INCLUDES := ../../include/

--- a/include/iso_alloc_ds.h
+++ b/include/iso_alloc_ds.h
@@ -70,8 +70,6 @@ typedef struct iso_alloc_big_zone_t {
  * that hold chunks containing caller data */
 typedef struct {
     uint16_t zones_used;
-    void *guard_below;
-    void *guard_above;
     uint32_t zone_retirement_shf;
     uintptr_t *chunk_quarantine;
     size_t chunk_quarantine_count;
@@ -93,6 +91,7 @@ typedef struct {
     iso_alloc_big_zone_t *big_zone_head;
     iso_alloc_zone_t *zones;
     size_t zones_size;
+    uint64_t seed;
 #if THREAD_SUPPORT
 #if USE_SPINLOCK
     atomic_flag big_zone_busy_flag;

--- a/include/iso_alloc_sanity.h
+++ b/include/iso_alloc_sanity.h
@@ -53,8 +53,6 @@ extern int32_t _sane_sampled;
 extern uint8_t _sane_cache[SANE_CACHE_SIZE];
 
 typedef struct {
-    void *guard_below;
-    void *guard_above;
     void *address;
     size_t orig_size;
     bool right_aligned;

--- a/src/iso_alloc_mem_tags.c
+++ b/src/iso_alloc_mem_tags.c
@@ -60,7 +60,7 @@ INTERNAL_HIDDEN bool _refresh_zone_mem_tags(iso_alloc_zone_t *zone) {
         size_t tms = s / sizeof(uint64_t);
 
         for(uint64_t o = 0; o > tms; o++) {
-            _mtp[o] = rand_uint64();
+            _mtp[o] = us_rand_uint64(&_root->seed);
         }
 
         return true;

--- a/src/iso_alloc_profiler.c
+++ b/src/iso_alloc_profiler.c
@@ -376,7 +376,7 @@ INTERNAL_HIDDEN void _iso_alloc_profile(size_t size) {
     _alloc_count++;
 
     /* Don't run the profiler on every allocation */
-    if(LIKELY((rand_uint64() % PROFILER_ODDS) != 1)) {
+    if(LIKELY((us_rand_uint64(&_root->seed) % PROFILER_ODDS) != 1)) {
         return;
     }
 
@@ -439,7 +439,7 @@ INTERNAL_HIDDEN void _iso_free_profile(void) {
     _free_count++;
 
     /* Don't run the profiler on every allocation */
-    if(LIKELY((rand_uint64() % PROFILER_ODDS) != 1)) {
+    if(LIKELY((us_rand_uint64(&_root->seed) % PROFILER_ODDS) != 1)) {
         return;
     }
 

--- a/src/iso_alloc_random.c
+++ b/src/iso_alloc_random.c
@@ -21,15 +21,24 @@
 #error "unknown OS"
 #endif
 
-
 /* Adapted from Daniel Lemire (@lemire). The code can be found at
  * https://github.com/lemire/testingRNG/blob/master/source/wyhash.h
- * This is adapted from wyhash from @wangyi-fudan */
+ * Which is adapted from wyhash from @wangyi-fudan
+ *
+ * This is not suitable for anything cryptographic. We use it in
+ * IsoAlloc for generating pointer masks, shuffling arrays etc,
+ * and the initial seed is refreshed with rand_uint64() each time
+ * we create a new zone.
+ *
+ * The magic values below are just random 64 bit primes. These values
+ * are combined with our seed and then run through the mum function.
+ * See the original wyhash paper for more details.
+ * https://github.com/wangyi-fudan/wyhash/ */
 INTERNAL_HIDDEN INLINE uint64_t us_rand_uint64(uint64_t *seed) {
-    *seed += 0x60bee2bee120fc15;
-    __uint128_t tmp = (__uint128_t)*seed * 0xa3b195354a39b70d;
+    *seed += 0x5d6447c8df9375b5;
+    __uint128_t tmp = (__uint128_t) *seed * 0x3c5829f2fb3c3eef;
     uint64_t m1 = (tmp >> 64) ^ tmp;
-    tmp = (__uint128_t)m1 * 0x1b03738712fad5c9;
+    tmp = (__uint128_t) m1 * 0x4f38e4ccc1b0ea59;
     return (tmp >> 64) ^ tmp;
 }
 

--- a/tests/pool_test.c
+++ b/tests/pool_test.c
@@ -24,7 +24,8 @@ int allocate(size_t array_size, size_t allocation_size) {
         void *p = iso_alloc_from_zone(zone);
 
         if(p == NULL) {
-            LOG_AND_ABORT("Failed to allocate %ld bytes after %d total allocations from zone with %d total chunks", allocation_size, alloc_count, total_chunks);
+            LOG_AND_ABORT("Failed to allocate %ld bytes after %d total allocations from zone with %d total chunks",
+                          allocation_size, alloc_count, total_chunks);
         }
 
         alloc_count++;


### PR DESCRIPTION
* Reduce syscalls made for both RNG and madvise/guard page creation
* Cleanup the wyhash RNG and use new unique 64 bit primes
* Fix a bug in how we sometimes right adjust sampled allocations