### PR TITLE
enable mt c++ tests on macos finally.

### DIFF
--- a/include/os/macos.h
+++ b/include/os/macos.h
@@ -5,6 +5,17 @@
 
 #include <libkern/OSByteOrder.h>
 #include <mach/vm_statistics.h>
+#include <pthread.h>
 #define bswap_32(x) OSSwapInt32(x)
 #define bswap_64(x) OSSwapInt64(x)
 #define ENVIRON NULL
+
+/*
+ * On pthread_exit, it expects to be dealing with libmalloc
+ * rather than isoalloc at releasing time
+ */
+__attribute__((weak)) void _pthread_tsd_cleanup(pthread_t);
+void _pthread_tsd_cleanup(pthread_t p)
+{
+    (void)p;
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -95,7 +95,6 @@ int main(int argc, char *argv[]) {
         auto d = std::make_unique<Derived>(i);
     }
 
-#ifndef __APPLE__
     for(size_t i = 0; i < 4; i++) {
         std::array<std::thread, 4> t;
         for(size_t z = 0; z < 4; z++) {
@@ -103,7 +102,6 @@ int main(int argc, char *argv[]) {
             t[i].join();
         }
     }
-#endif
 
     iso_verify_zones();
 


### PR DESCRIPTION
the issue came from _pthread_exit calling _pthread_tsd_cleanup
 expecting to be dealing with libmalloc pointers rather than isoalloc's.