### PR TITLE
add verify tag function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,9 @@ tests: clean library_debug_unit_tests
 	@echo "make tests"
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/rand_freelist.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/rand_freelist $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/tagged_ptr_test.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/tagged_ptr_test $(LDFLAGS)
+	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/uaf_tag_ptr_test.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/uaf_tag_ptr_test $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/bad_tag_ptr_test.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/bad_tag_ptr_test $(LDFLAGS)
+	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/verify_tag_ptr_test.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/verify_tag_ptr_test $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/tests.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/tests $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/uaf.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/uaf $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/interfaces_test.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/interfaces_test $(LDFLAGS)

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ If all else fails please file an issue on the [github project](https://github.co
 
 `void *iso_alloc_from_zone_tagged(iso_alloc_zone_handle *zone)` - Same as `iso_alloc_from_zone` but returns a tagged pointer if `MEMORY_TAGGING` is enabled.
 
+`void iso_alloc_verify_ptr_tag(void *p, iso_alloc_zone_handle *zone)` - Verifies the tag for a pointer is correct, aborts if not. Requires `MEMORY_TAGGING`.
+
 `void iso_alloc_destroy_zone(iso_alloc_zone_handle *zone)` - Destroy a zone created with `iso_alloc_from_zone`.
 
 `void *iso_alloc_tag_ptr(void *p, iso_alloc_zone_handle *zone)` - Tags a pointer from a private zone if `MEMORY_TAGGING` is enabled.

--- a/include/iso_alloc.h
+++ b/include/iso_alloc.h
@@ -50,6 +50,7 @@ EXTERNAL_API void iso_free_permanently(void *p);
 EXTERNAL_API void iso_free_from_zone(void *p, iso_alloc_zone_handle *zone);
 EXTERNAL_API void iso_free_from_zone_permanently(void *p, iso_alloc_zone_handle *zone);
 EXTERNAL_API size_t iso_chunksz(void *p);
+EXTERNAL_API void iso_alloc_verify_ptr_tag(void *p, iso_alloc_zone_handle *zone);
 EXTERNAL_API NO_DISCARD uint8_t iso_alloc_get_mem_tag(void *p, iso_alloc_zone_handle *zone);
 EXTERNAL_API NO_DISCARD ASSUME_ALIGNED char *iso_strdup(const char *str);
 EXTERNAL_API NO_DISCARD ASSUME_ALIGNED char *iso_strdup_from_zone(iso_alloc_zone_handle *zone, const char *str);

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -395,6 +395,7 @@ INTERNAL_HIDDEN uint64_t __iso_alloc_mem_usage(void);
 INTERNAL_HIDDEN INLINE uint64_t us_rand_uint64(uint64_t *seed);
 INTERNAL_HIDDEN INLINE uint64_t rand_uint64(void);
 INTERNAL_HIDDEN uint8_t _iso_alloc_get_mem_tag(void *p, iso_alloc_zone_t *zone);
+INTERNAL_HIDDEN void _iso_alloc_verify_tag(void *p, iso_alloc_zone_t *zone);
 INTERNAL_HIDDEN size_t _iso_alloc_print_stats(void);
 INTERNAL_HIDDEN size_t _iso_chunk_size(void *p);
 INTERNAL_HIDDEN int64_t check_canary_no_abort(iso_alloc_zone_t *zone, const void *p);

--- a/src/iso_alloc_interfaces.c
+++ b/src/iso_alloc_interfaces.c
@@ -201,6 +201,16 @@ EXTERNAL_API NO_DISCARD void *iso_alloc_untag_ptr(void *p, iso_alloc_zone_handle
     return _untag_ptr(p, zone);
 }
 
+EXTERNAL_API void iso_alloc_verify_ptr_tag(void *p, iso_alloc_zone_handle *zone) {
+    if(zone == NULL) {
+        return;
+    }
+
+    UNMASK_ZONE_HANDLE(zone);
+    _iso_alloc_verify_tag(p, zone);
+    return;
+}
+
 EXTERNAL_API NO_DISCARD uint8_t iso_alloc_get_mem_tag(void *p, iso_alloc_zone_handle *zone) {
     if(zone == NULL || p == NULL) {
         return 0;

--- a/src/iso_alloc_mem_tags.c
+++ b/src/iso_alloc_mem_tags.c
@@ -28,6 +28,22 @@ INTERNAL_HIDDEN uint8_t _iso_alloc_get_mem_tag(void *p, iso_alloc_zone_t *zone) 
 #endif
 }
 
+INTERNAL_HIDDEN void _iso_alloc_verify_tag(void *p, iso_alloc_zone_t *zone) {
+#if MEMORY_TAGGING
+    if(UNLIKELY(p == NULL || zone == NULL)) {
+        return;
+    }
+
+    void *untagged_p = (void *) ((uintptr_t) p & TAGGED_PTR_MASK);
+    const uint64_t tag = _iso_alloc_get_mem_tag(untagged_p, zone);
+
+    if(tag != ((uintptr_t) p & IS_TAGGED_PTR_MASK)) {
+        LOG_AND_ABORT("Pointer %p has wrong tag %x, expected %x", p, ((uintptr_t) p & IS_TAGGED_PTR_MASK), tag);
+    }
+#endif
+    return;
+}
+
 INTERNAL_HIDDEN void *_tag_ptr(void *p, iso_alloc_zone_t *zone) {
 #if MEMORY_TAGGING
     if(UNLIKELY(p == NULL || zone == NULL)) {

--- a/tests/uaf_tag_ptr_test.c
+++ b/tests/uaf_tag_ptr_test.c
@@ -1,0 +1,36 @@
+/* iso_alloc uaf_tag_ptr_test.c
+ * Copyright 2022 - chris.rohlf@gmail.com */
+
+#include <stdio.h>
+#include <string.h>
+#include "iso_alloc.h"
+#include "iso_alloc_internal.h"
+
+#define SIZE 256
+
+int main(int argc, char *argv[]) {
+    iso_alloc_zone_handle *_zone_handle = iso_alloc_new_zone(SIZE);
+
+    if(_zone_handle == NULL) {
+        abort();
+    }
+
+    void *p = iso_alloc_from_zone_tagged(_zone_handle);
+    void *up = iso_alloc_untag_ptr(p, _zone_handle);
+    iso_free_from_zone(up, _zone_handle);
+    iso_flush_caches();
+    p = iso_alloc_untag_ptr(p, _zone_handle);
+
+    /* This should crash on systems without TBI as p is
+     * already free and the untagging operation should
+     * result in a bad pointer */
+    memset(p, 0x41, SIZE);
+
+    iso_alloc_destroy_zone(_zone_handle);
+
+#if !MEMORY_TAGGING
+    return -1;
+#endif
+
+    return 0;
+}

--- a/tests/verify_tag_ptr_test.c
+++ b/tests/verify_tag_ptr_test.c
@@ -1,0 +1,38 @@
+/* iso_alloc verify_tag_ptr_test.c
+ * Copyright 2022 - chris.rohlf@gmail.com */
+
+#include <stdio.h>
+#include <string.h>
+#include "iso_alloc.h"
+#include "iso_alloc_internal.h"
+
+#define SIZE 256
+
+int main(int argc, char *argv[]) {
+    iso_alloc_zone_handle *_zone_handle = iso_alloc_new_zone(SIZE);
+
+    if(_zone_handle == NULL) {
+        abort();
+    }
+
+    void *p = iso_alloc_from_zone_tagged(_zone_handle);
+    void *up = iso_alloc_untag_ptr(p, _zone_handle);
+    iso_free_from_zone(up, _zone_handle);
+    iso_flush_caches();
+    iso_alloc_verify_ptr_tag(p, _zone_handle);
+
+    p = iso_alloc_untag_ptr(p, _zone_handle);
+
+    /* This should crash on systems without TBI as p is
+     * already free and the untagging operation should
+     * result in a bad pointer */
+    memset(p, 0x41, SIZE);
+
+    iso_alloc_destroy_zone(_zone_handle);
+
+#if !MEMORY_TAGGING
+    return -1;
+#endif
+
+    return 0;
+}

--- a/tests/verify_tag_ptr_test.c
+++ b/tests/verify_tag_ptr_test.c
@@ -19,15 +19,8 @@ int main(int argc, char *argv[]) {
     void *up = iso_alloc_untag_ptr(p, _zone_handle);
     iso_free_from_zone(up, _zone_handle);
     iso_flush_caches();
+    /* The free() path will have changed the tag for this pointer */
     iso_alloc_verify_ptr_tag(p, _zone_handle);
-
-    p = iso_alloc_untag_ptr(p, _zone_handle);
-
-    /* This should crash on systems without TBI as p is
-     * already free and the untagging operation should
-     * result in a bad pointer */
-    memset(p, 0x41, SIZE);
-
     iso_alloc_destroy_zone(_zone_handle);
 
 #if !MEMORY_TAGGING

--- a/utils/run_tests.sh
+++ b/utils/run_tests.sh
@@ -31,7 +31,8 @@ done
 
 fail_tests=("double_free" "big_double_free" "heap_overflow" "heap_underflow"
             "leaks_test" "wild_free" "unaligned_free" "incorrect_chunk_size_multiple"
-            "big_canary_test" "zero_alloc" "sized_free" "bad_tag_ptr_test")
+            "big_canary_test" "zero_alloc" "sized_free" "bad_tag_ptr_test"
+            "verify_tag_ptr_test")
 
 for t in "${fail_tests[@]}"; do
     echo -n "Running $t test"


### PR DESCRIPTION
Introduce the `iso_alloc_verify_ptr_tag` function so systems with TBI can verify the pointer tag without removing it.