### PR TITLE
Makefile cleanup, local free list pointer

### DIFF
--- a/include/iso_alloc.h
+++ b/include/iso_alloc.h
@@ -27,8 +27,12 @@ static_assert(sizeof(size_t) == 8, "IsoAlloc requires 64 bit size_t");
 #define ZONE_ALLOC_SIZE __attribute__((alloc_size(2)))
 #define ASSUME_ALIGNED __attribute__((assume_aligned(8)))
 
+#if MASK_PTRS
 #define UNMASK_ZONE_HANDLE(zone) \
     zone = (iso_alloc_zone_handle *) ((uintptr_t) zone ^ (uintptr_t) _root->zone_handle_mask);
+#else
+#define UNMASK_ZONE_HANDLE(zone) zone = zone;
+#endif
 
 typedef void iso_alloc_zone_handle;
 

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -199,6 +199,7 @@ assert(sizeof(size_t) >= 64)
 #define ROUND_DOWN_PAGE(n) \
     (ROUND_UP_PAGE(n) - g_page_size)
 
+#if MASK_PTRS
 #define MASK_ZONE_PTRS(zone) \
     MASK_BITMAP_PTRS(zone);  \
     MASK_USER_PTRS(zone);
@@ -223,6 +224,17 @@ assert(sizeof(size_t) >= 64)
 
 #define UNMASK_BIG_ZONE_NEXT(bnp) \
     ((iso_alloc_big_zone_t *) ((uintptr_t) _root->big_zone_next_mask ^ (uintptr_t) bnp))
+#else
+#define MASK_ZONE_PTRS(zone)
+#define UNMASK_ZONE_PTRS(zone)
+#define MASK_BITMAP_PTRS(zone)
+#define MASK_USER_PTRS(zone)
+#define UNMASK_USER_PTR(zone) (void *) zone->user_pages_start
+#define UNMASK_BITMAP_PTR(zone) (void *) zone->bitmap_start
+#define MASK_BIG_ZONE_NEXT(bnp) bnp
+#define UNMASK_BIG_ZONE_NEXT(bnp) bnp
+#endif
+
 
 /* Cap our big zones at 4GB of memory */
 #define BIG_SZ_MAX 4294967296

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -235,7 +235,6 @@ assert(sizeof(size_t) >= 64)
 #define UNMASK_BIG_ZONE_NEXT(bnp) bnp
 #endif
 
-
 /* Cap our big zones at 4GB of memory */
 #define BIG_SZ_MAX 4294967296
 


### PR DESCRIPTION
* Remove legacy portion of Makefile named `SECURITY_FLAGS` and break them out into their own defines
* Add `MASK_PTRS` define for masking zone pointers. This is enabled by default.
* Use a pointer to the freelist instead of dereferencing `zone->`