### PR TITLE
memmove sanity check proposal.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ SCHED_GETCPU =
 ## much of a performance penalty
 ALLOC_SANITY = -DALLOC_SANITY=0
 
-## Enable hooking of memcpy/memset to detect out of bounds
+## Enable hooking of memcpy/memmove/memset to detect out of bounds
 ## r/w operations on chunks allocated with IsoAlloc. Does
 ## not require ALLOC_SANITY is enabled. On MacOS you need
 ## to set FORTIFY_SOURCE to 0. Leave these commented if
@@ -389,7 +389,8 @@ libc_sanity_tests: clean library_debug_unit_tests
 	@echo "make libc_sanity_tests"
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/memset_sanity.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/memset_sanity $(LDFLAGS)
 	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/memcpy_sanity.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/memcpy_sanity $(LDFLAGS)
-	build/memset_sanity ; build/memcpy_sanity
+	$(CC) $(CFLAGS) $(EXE_CFLAGS) $(DEBUG_LOG_FLAGS) $(GDB_FLAGS) $(OS_FLAGS) tests/memmove_sanity.c $(ISO_ALLOC_PRINTF_SRC) -o $(BUILD_DIR)/memmove_sanity $(LDFLAGS)
+	build/memset_sanity ; build/memcpy_sanity; build/memmove_sanity;
 
 fuzz_test: clean library_debug_unit_tests
 	@echo "make fuzz_test"

--- a/include/iso_alloc_sanity.h
+++ b/include/iso_alloc_sanity.h
@@ -76,5 +76,7 @@ INTERNAL_HIDDEN _sane_allocation_t *_get_sane_alloc(void *p);
 
 INTERNAL_HIDDEN INLINE void *__iso_memcpy(void *dest, const void *src, size_t n);
 INTERNAL_HIDDEN void *_iso_alloc_memcpy(void *dest, const void *src, size_t n);
+INTERNAL_HIDDEN INLINE void *__iso_memmove(void *dest, const void *src, size_t n);
+INTERNAL_HIDDEN void *_iso_alloc_memmove(void *dest, const void *src, size_t n);
 INTERNAL_HIDDEN INLINE void *__iso_memset(void *dest, int b, size_t n);
 INTERNAL_HIDDEN void *_iso_alloc_memset(void *dest, int b, size_t n);

--- a/src/libc_hook.c
+++ b/src/libc_hook.c
@@ -9,6 +9,10 @@
 EXTERNAL_API void *memcpy(void *restrict dest, const void *restrict src, size_t n) {
     return _iso_alloc_memcpy(dest, src, n);
 }
+
+EXTERNAL_API void *memmove(void *dest, const void *src, size_t n) {
+    return _iso_alloc_memmove(dest, src, n);
+}
 #endif
 
 #if MEMSET_SANITY

--- a/tests/memmove_sanity.c
+++ b/tests/memmove_sanity.c
@@ -1,0 +1,27 @@
+/* iso_alloc memmove_sanity.c
+ * Copyright 2023 - chris.rohlf@gmail.com */
+
+#include "iso_alloc.h"
+#include "iso_alloc_internal.h"
+
+#if !MEMCPY_SANITY
+#error "This test intended to be run with -DMEMCPY_SANITY=1"
+#endif
+
+int main(int argc, char *argv[]) {
+    uint8_t *p = NULL;
+    p = (uint8_t *) iso_alloc(SMALLEST_CHUNK_SZ);
+
+    const char *A = "ABCABCABCABCABCABCABCABCABCABCABCABCABCAA"
+                    "ABCABCABCABCABCABCABCABCABCABCABCABCABCAA"
+                    "ABCABCABCABCABCABCABCABCABCABCABCABCABCAA";
+    size_t len = strlen(A);
+    memcpy(p, A, SMALLEST_CHUNK_SZ);
+
+    memmove(&p[0], &p[64], len - 64);
+
+    iso_free(p);
+    iso_verify_zones();
+
+    return OK;
+}


### PR DESCRIPTION
purposely reuses MEMCPY_SANITY flag.

closes #172