### PR TITLE
improve accuracy of security property table

### DIFF
--- a/SECURITY_COMPARISON.MD
+++ b/SECURITY_COMPARISON.MD
@@ -24,20 +24,20 @@ Heap allocators hide incredible complexity behind `malloc` and `free`. They must
 |Double Free Detection  |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:x:              |:heavy_check_mark:|:heavy_plus_sign: |:heavy_check_mark:|:heavy_check_mark:|:grey_question:   |:heavy_check_mark:
 |Chunk Alignment Check  |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:x:              |:heavy_check_mark:|:heavy_plus_sign: |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:
 |Out Of Band Metadata   |:heavy_check_mark:|:x:               |:x:               |:x:              |:x:               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:               |:heavy_check_mark:
-|Permanent Frees        |:heavy_minus_sign:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:x:
+|Permanent Frees        |:heavy_minus_sign:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_plus_sign: |:x:               |:x:
 |Freed Chunk Sanitization   |:heavy_plus_sign:|:heavy_check_mark:|:x:            |:x:              |:x:               |:heavy_plus_sign: |:x:               |:heavy_check_mark:|:heavy_plus_sign: |:x:
 |Adjacent Chunk Verification|:heavy_check_mark:|:heavy_check_mark:|:x:           |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:x:
-|Delayed Free           |:heavy_check_mark:|:heavy_check_mark:|:x:               |:x:              |:x:               |:x:               |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:heavy_check_mark:
-|Dangling Pointer Detection |:heavy_plus_sign:|:x:            |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:heavy_plus_sign: |:x:
-|GWP-ASAN Like Sampling |:heavy_plus_sign: |:heavy_plus_sign: |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:grey_question:   |:x:
+|Delayed Free           |:heavy_check_mark:|:heavy_check_mark:|:x:               |:x:              |:x:               |:heavy_plus_sign: |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:heavy_check_mark:
+|Dangling Pointer Detection |:heavy_plus_sign:|:x:            |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_check_mark:|:heavy_plus_sign: |:x:
+|GWP-ASAN Like Sampling |:heavy_plus_sign: |:heavy_plus_sign: |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_check_mark:|:grey_question:   |:x:
 |Size Mismatch Detection|:heavy_check_mark:|:heavy_check_mark:|:x:               |:x:              |:heavy_plus_sign: |:x:               |:x:               |:heavy_check_mark:|:heavy_plus_sign: |:grey_question:
 |ARM Memory Tagging     |:x:               |:heavy_check_mark:|:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:grey_question:
-|Zone/Chunk CPU Pinning |:heavy_plus_sign: |:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:x:
+|Zone/Chunk CPU/thread Pinning |:heavy_plus_sign: |:x:        |:x:               |:x:              |:x:               |:heavy_check_mark:|:x:               |:heavy_check_mark:|:x:               |:x:
 |Chunk Race Error Detection |:x:           |:heavy_check_mark:|:grey_question:   |:x:              |:x:               |:x:               |:grey_question:   |:grey_question:   |:grey_question:   |:heavy_plus_sign:
 |Zero Size Allocation Special Handling|:heavy_check_mark:|:x: |:grey_question:   |:grey_question:  |:x:               |:x:               |:x:               |:heavy_check_mark:|:x:               |:x:
 |Read-only global structure|:heavy_minus_sign:|:x:            |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_check_mark:|:x:               |:x:
 |SW Memory Tagging      |:heavy_minus_sign:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:heavy_check_mark:|:x:
-|Guarded Memcpy         |:heavy_check_mark:               |:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:heavy_check_mark:
+|Guarded Memcpy         |:heavy_check_mark:|:x:               |:x:               |:x:              |:x:               |:x:               |:heavy_plus_sign: |:x:               |:x:               |:heavy_check_mark:
 
 **Lexicon**
 


### PR DESCRIPTION
This makes adjustments based on the current set of listed properties but there's a lot of room for improvement by splitting up the overly coarse properties like randomization, guard pages, double free detection, etc. which don't differentiate between dramatically different approach in how things are done between some of the allocators including distinctions between probabilistic vs. deterministic detection of double frees and how guard pages / randomization are used rather than just whether it's used at all.

Permanent frees:

    hardened_malloc uses a virtual memory quarantine for large allocations
    with a configurable size so you can enable permanent frees of large
    allocations if you want it. The address space will eventually run out
    but it purges the freed large allocations back to fresh PROT_NONE
    regions so they won't directly consume memory, only indirectly via the
    VMAs. The random guard regions around allocations are also kept as part
    of them being quarantined, which means address space gets depleted
    faster but improves the security properties because the kernel can't end
    up placing new allocations in the freed guard regions.

    Small allocation quarantine size is also configurable but only meant to
    be used in a limited way since it massively increases memory usage and
    the regions for small allocations are entirely reserved in advanced with
    limited size so the address space within them would be quickly depleted.
    It also only purges memory for fully free slabs, not slabs that are
    partially quarantined and partially freed. malloc_trim does purge memory
    for quarantined allocations that are at least page aligned (extended
    size classes, which are 20480 through 131072 for the current
    4096 byte supported page size). This may change in the future but it's
    never going to be intended to be used for permanent free of small
    allocations in long lived programs unless address spaces get much
    larger, although you could get away with it for short lived programs,
    and the improvements will make it more usable for that.

Delayed free:

    This is an optional feature in jemalloc.

Dangling pointer detection:

    Dangling pointer detection is done in hardened_malloc via the write after
    free check performed at allocation time which checks that the data is still
    zeroed from when it was zeroed at free time.  It's disabled for the lite
    variant, which only keeps the optional zero-on-free and canary features.

    Slabs also get changed back to fresh PROT_NONE regions once you go beyond the
    slab cache amount for the size class within the arena, but the
    write-after-free check feature enabled by default for the normal variant is
    the main way this is done.

GWP ASan like sampling:

    hardened_malloc always places randomly sized guard regions around large
    allocations and by default places a guard slab between each slab. This
    means the small allocation randomly placed at the end has a guard region
    following it which is essentially like GWP ASan sampling but enabled by
    default and much cheaper because the guard slabs are simply slabs which
    didn't get used from the isolated size class regions. There's no system
    call to create the guard slabs but rather as slabs get unprotected to
    use them they are left alone. This also means 50% of the used portion of the
    size class regions are PROT_NONE memory with the default interval of 1 (can be
    raised for fewer guard slabs, which is done for lite variant) and the
    intention is to further improve this with additional random skips to make the
    offset of used slabs unpredictable along with adding the option to make it
    even more sparse than 50% usage.

    There's always use-after-free detection via the virtual memory
    quarantine for large allocations (PROT_NONE memory) and via the
    combination of the slab allocation quarantine with the write-after-free
    check for small allocations. The quarantine is partly randomized so
    allocations can stay inside it for an extremely long time and it will
    vary based on program run, so different issues may be caught for
    different program runs. This is essentially a form of sampling too
    since it ends up randomly keeping some in quarantine much longer.

Zone/Chunk CPU pinning:

    hardened_malloc has jemalloc-style arenas where threads are pinned to an
    arena in round robin so it does have something like this. The granularity
    depends on the number of arenas, which is 4 by default. In jemalloc, this
    is 4x the number of CPU cores by default. jemalloc also has a mode where
    it uses 1:1 ratio with sched_getcpu(). CPU can change between call to
    sched_getcpu() and using the arena, but there was upstream Linux kernel
    work aimed at avoiding this in order to make per-CPU caches in userspace
    with no locking.

Guarded Memcpy:

    Guarded memcpy is support via the hardened_malloc malloc_object_size and
    malloc_object_size_fast API which has historically been used by
    GrapheneOS to perform checks on libc system calls and is entirely usable
    for the string functions too. The reason for the distinction is to avoid
    locking to check if the slab and/or slot within the slab are free for
    the fast function meant for usage in string functions while the overhead
    can likely be accepted for system calls especially since locking is done
    with a single per-size-class lock for each size class within each arena
    with no other locking beyond system call locking in the kernel which is
    not relevant to these.

    hardened_malloc doesn't currently provide overrides for these functions so
    marking this as needing configuration seems reasonable. It could provide
    that at least as an example but the intention has always been that it gets
    integrated into libc for more serious deployments like on GrapheneOS.

    This feature is currently missing from GrapheneOS but was present in
    the past and just hasn't been ported forward to newer versions of
    Bionic yet.