### PR TITLE
Add option for naming pages in Linux 5.17

### DIFF
--- a/include/os/linux.h
+++ b/include/os/linux.h
@@ -5,9 +5,27 @@
 
 #include <sys/prctl.h>
 #include <byteswap.h>
+/* Get linux kernel version */
+#include <linux/version.h>
 
 #if defined(CPU_PIN) && defined(_GNU_SOURCE) && defined(__linux__)
 #include <sched.h>
+#endif
+
+/* In Linux kernel versions greater than 5.17.0, it is also possible 
+ * to name anonymous VMA. See
+ * https://kernelnewbies.org/Linux_5.17#Support_giving_names_to_anonymous_memory */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+/* Use this macro can allow for compatibility with older versions while 
+ * introducing new functionality */
+#define KERNEL_VERSION_SEQ_5_17 1
+/* Same as android.h. */
+#ifndef PR_SET_VMA
+#define PR_SET_VMA 0x53564d41
+#endif
+#ifndef PR_SET_VMA_ANON_NAME
+#define PR_SET_VMA_ANON_NAME 0
+#endif
 #endif
 
 #define ENVIRON environ

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -479,7 +479,7 @@ INTERNAL_HIDDEN iso_alloc_zone_t *_iso_new_zone(size_t size, bool internal, int3
 
     char *name = NULL;
 
-#if NAMED_MAPPINGS && __ANDROID__
+#if NAMED_MAPPINGS && (__ANDROID__ || KERNEL_VERSION_SEQ_5_17)
     if(internal == true) {
         name = INTERNAL_UZ_NAME;
     } else {
@@ -503,7 +503,7 @@ INTERNAL_HIDDEN iso_alloc_zone_t *_iso_new_zone(size_t size, bool internal, int3
 #endif
     void *p = mmap_rw_pages(total_size, false, name);
 
-#if __ANDROID__ && NAMED_MAPPINGS && MEMORY_TAGGING
+#if(__ANDROID__ || KERNEL_VERSION_SEQ_5_17) && NAMED_MAPPINGS && MEMORY_TAGGING
     if(new_zone->tagged == false) {
         name = MEM_TAG_NAME;
     }

--- a/src/iso_alloc_util.c
+++ b/src/iso_alloc_util.c
@@ -167,7 +167,7 @@ INTERNAL_HIDDEN void mprotect_pages(void *p, size_t size, int32_t protection) {
 }
 
 INTERNAL_HIDDEN int32_t name_mapping(void *p, size_t sz, const char *name) {
-#if NAMED_MAPPINGS && __ANDROID__
+#if NAMED_MAPPINGS && (__ANDROID__ || KERNEL_VERSION_SEQ_5_17)
     return prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, p, sz, name);
 #else
     return 0;


### PR DESCRIPTION
From Linux 5.17 onwards, it is now possible to name anonymous memory, similar to the Android system. Therefore, I have added a macro that allows you to choose whether or not to use this feature. For more information, you can refer to
https://kernelnewbies.org/Linux_5.17#Support_giving_names_to_anonymous_memory.