### PR TITLE
more accurate hardened_malloc information

### DIFF
--- a/SECURITY_COMPARISON.MD
+++ b/SECURITY_COMPARISON.MD
@@ -13,7 +13,7 @@ Heap allocators hide incredible complexity behind `malloc` and `free`. They must
 :grey_question: = Todo
 
 
-| Security Feature                    | isoalloc         | scudo            | mimalloc         | tcmalloc        | ptmalloc3        | jemalloc         | musl's malloc-ng | malloc_hardened  | PartitionAlloc   | snmalloc |
+| Security Feature                    | isoalloc         | scudo            | mimalloc         | tcmalloc        | ptmalloc3        | jemalloc         | musl's malloc-ng | hardened_malloc  | PartitionAlloc   | snmalloc |
 |:-----------------------------------:|:----------------:|:----------------:|:----------------:|:---------------:|:----------------:|:----------------:|:----------------:|:----------------:|:----------------:|:----------------:|
 |Memory Isolation                     |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:              |:x:               |:grey_question:   |:x:               |:heavy_check_mark:|:heavy_check_mark:|:grey_question:
 |Canaries                             |:heavy_check_mark:|:heavy_check_mark:|:x:               |:x:              |:heavy_plus_sign: |:x:               |:heavy_check_mark:|:heavy_check_mark:|:grey_question:   |:heavy_check_mark:
@@ -26,19 +26,19 @@ Heap allocators hide incredible complexity behind `malloc` and `free`. They must
 |Out Of Band Metadata                 |:heavy_check_mark:|:x:               |:x:               |:x:              |:x:               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:               |:heavy_check_mark:
 |Permanent Frees                      |:heavy_minus_sign:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:x:
 |Freed Chunk Sanitization             |:heavy_plus_sign: |:heavy_check_mark:|:x:               |:x:              |:x:               |:heavy_plus_sign: |:x:               |:heavy_check_mark:|:heavy_plus_sign: |:x:
-|Adjacent Chunk Verification          |:heavy_check_mark:|:heavy_check_mark:|:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:x:
+|Adjacent Chunk Verification          |:heavy_check_mark:|:heavy_check_mark:|:x:               |:x:              |:x:               |:x:               |:x:               |:grey_question:   |:x:               |:x:
 |Delayed Free                         |:heavy_check_mark:|:heavy_check_mark:|:x:               |:x:              |:x:               |:x:               |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:heavy_check_mark:
-|Dangling Pointer Detection           |:heavy_plus_sign: |:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:heavy_plus_sign: |:x:
-|GWP-ASAN Like Sampling               |:heavy_plus_sign: |:heavy_plus_sign: |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:grey_question:   |:x:
+|Dangling Pointer Detection           |:heavy_plus_sign: |:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_check_mark:|:heavy_plus_sign: |:x:
+|GWP-ASAN Like Sampling               |:heavy_plus_sign: |:heavy_plus_sign: |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_check_mark:|:grey_question:   |:x:
 |Size Mismatch Detection              |:heavy_check_mark:|:heavy_check_mark:|:x:               |:x:              |:heavy_plus_sign: |:x:               |:x:               |:heavy_check_mark:|:heavy_plus_sign: |:grey_question:
 |ARM Memory Tagging                   |:x:               |:heavy_check_mark:|:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:grey_question:
-|Zone/Chunk CPU Pinning               |:heavy_plus_sign: |:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:x:
+|Zone/Chunk CPU/Thread Pinning        |:heavy_plus_sign: |:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_check_mark:|:x:               |:x:
 |Chunk Race Error Detection           |:x:               |:heavy_check_mark:|:grey_question:   |:x:              |:x:               |:x:               |:grey_question:   |:grey_question:   |:grey_question:   |:heavy_plus_sign:
 |Zero Size Allocation Special Handling|:heavy_check_mark:|:x:               |:grey_question:   |:grey_question:  |:x:               |:x:               |:x:               |:heavy_check_mark:|:x:               |:x:
 |Read-only global structure           |:heavy_minus_sign:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_check_mark:|:x:               |:x:
 |SW Memory Tagging                    |:heavy_minus_sign:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:heavy_check_mark:|:x:
-|Guarded memcpy/memmove               |:heavy_check_mark:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:heavy_check_mark:
-|Automatic initialization             |:x:               |:heavy_plus_sign: |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:x:
+|Guarded memcpy/memmove               |:heavy_check_mark:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_minus_sign:|:x:               |:heavy_check_mark:
+|Automatic initialization             |:x:               |:heavy_plus_sign: |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_check_mark:|:x:               |:x:
 
 **Lexicon**
 


### PR DESCRIPTION
Adjacent Chunk Verification: hardened_malloc isn't designed in a way that this is applicable. There isn't metadata that's either inline or in proximity to allocations, only a single global metadata region with a high entropy random base within a large PROT_NONE region. Due to the current lack of a "not applicable" value, uses a question mark for now.

Dangling Pointer Detection: write-after-free detection based on checking that zero-on-free is intact at allocation time, free slabs are made back into PROT_NONE and placed into a free slab quarantine and large allocations have a virtual memory quarantine.

GWP-ASan Like Sampling: half of all slabs are guard slabs by default and allocation slot selection is randomized by default which provides random guard pages before some small allocations and after some small allocations. Large allocations have enforced randomly sized guards and a virtual memory quarantine. Our small and large allocation quarantines also use a random array in addition to a FIFO ring buffer. This means that allocations can randomly end up spending a long time quarantined if they aren't randomly chosen when other allocations of the same size class are freed, which is a somewhat similar concept taken from OpenBSD malloc and extended significantly.

Zone/Chunk CPU Pinning: arenas are pinned to threads in a static round robin approach. More arenas can be enabled to further separate where threads allocate. Providing alternate approaches is planned, but using a lot of arenas increases memory usage due to each having their own caches and quarantines along with their own external fragmentation from unused slots within partially filled slabs.

Guarded memcpy/memmove: hardened_malloc provides the necessary functions to implement dynamic heap overflow checks. We previously used this for the I/O system calls (read, write, etc.) and stdio (fread, fwrite, etc.) in Bionic libc, although we still have to port the Bionic side of it to current Android. hardened_malloc does this in a similar way as __builtin_object_size where the API can be passed any pointer and must return a valid upper bound on the size which is SIZE_MAX when completely unknown. It has both a fast API not requiring locking and a slower API requiring locking. The fast API currently doesn't check if the slot is currently active and is intended for APIs like memcpy while the slower API is intended for ones like read/write and perhaps even fread/fwrite.

Automatic initialization: hardened_malloc makes sure memory is zero on init via the write-after-free check in the default configuration. Memory is either zero because the memory is freshly allocated or because it checks that the memory is still zero from when it was zeroed on free. We may provide the option to write zeroes rather than checking for zeroes since it would be faster, but it would be less secure since it would not take advantage of the ability to make use-after-free exploitation less reliable. Our small and large allocation quarantines combine FIFO and random quarantines so the time allocations spend in the quarantine varies quite a bit.

Note (no change to table):

Permanent Free: should be clarified that this refers to an extension API provided by isoalloc. A table for extension APIs may be a better approach. It would be nice if these were done in a standard way, including support for dynamic heap overflow checks. Chunk Race Error Detection: not clear what this means, and doesn't seem applicable. Perhaps things based on having inline or nearby (not at a large random offset) should be in a dedicated table for allocators with that design.

SW Memory Tagging: this is a standard Android feature provided by Bionic, which is the main platform for hardened_malloc. There isn't a way to mark this Android-only, so a grey question mark seems best for now. It's unlikely we'll do this on other platforms. We expect the Pixel 8 and Pixel 8 Pro to ship with default disabled hardware memory tagging support so we'll soon be focused on that. Table is not currently changed but from our perspective, this is a libc feature since that's where it is in GrapheneOS.

Overall issue remaining after these changes: the table is mainly based around allocators like isoalloc, Scudo and PartitionAlloc. It doesn't include the main security properties provided by hardened_malloc. We'll likely make our own comparison, but we still want the info here to be accurate.