### PR TITLE
corrections for hardened_malloc

### DIFF
--- a/SECURITY_COMPARISON.MD
+++ b/SECURITY_COMPARISON.MD
@@ -24,21 +24,21 @@ Heap allocators hide incredible complexity behind `malloc` and `free`. They must
 |Double Free Detection                |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:x:              |:heavy_check_mark:|:heavy_plus_sign: |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:heavy_check_mark:
 |Chunk Alignment Check                |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:x:              |:heavy_check_mark:|:heavy_plus_sign: |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:
 |Out Of Band Metadata                 |:heavy_check_mark:|:x:               |:x:               |:x:              |:x:               |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:               |:heavy_check_mark:
-|Permanent Frees                      |:heavy_minus_sign:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:x:
+|Permanent Free API                   |:heavy_minus_sign:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:x:
 |Freed Chunk Sanitization             |:heavy_plus_sign: |:heavy_plus_sign: |:x:               |:x:              |:x:               |:heavy_plus_sign: |:x:               |:heavy_check_mark:|:heavy_plus_sign: |:x:
-|Adjacent Chunk Verification          |:heavy_check_mark:|:heavy_check_mark:|:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:x:
+|Adjacent Chunk Verification          |:heavy_check_mark:|:heavy_check_mark:|:x:               |:x:              |:x:               |:x:               |:x:               |:grey_question:   |:x:               |:x:
 |Delayed Free                         |:heavy_check_mark:|:heavy_check_mark:|:x:               |:x:              |:x:               |:heavy_plus_sign: |:heavy_check_mark:|:heavy_check_mark:|:heavy_plus_sign: |:heavy_check_mark:
-|Dangling Pointer Detection           |:heavy_plus_sign: |:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:heavy_plus_sign: |:x:
-|GWP-ASAN Like Sampling               |:heavy_plus_sign: |:heavy_plus_sign: |:x:               |:heavy_plus_sign:              |:x:               |:x:               |:x:               |:x:               |:grey_question:   |:x:
+|Dangling Pointer Detection           |:heavy_plus_sign: |:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_check_mark:|:heavy_plus_sign: |:x:
+|GWP-ASAN Like Sampling               |:heavy_plus_sign: |:heavy_plus_sign: |:x:               |:heavy_plus_sign:|:x:               |:x:               |:x:               |:heavy_check_mark:|:grey_question:   |:x:
 |Size Mismatch Detection              |:heavy_check_mark:|:heavy_check_mark:|:x:               |:x:              |:heavy_plus_sign: |:x:               |:x:               |:heavy_check_mark:|:heavy_plus_sign: |:heavy_plus_sign:
 |ARM Memory Tagging                   |:x:               |:heavy_check_mark:|:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:heavy_check_mark:               |:x:
-|Zone/Chunk CPU Pinning               |:heavy_plus_sign: |:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:x:
+|Zone/Chunk CPU/Thread Pinning        |:heavy_plus_sign: |:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_check_mark:|:x:               |:x:
 |Chunk Race Error Detection           |:x:               |:heavy_check_mark:|:grey_question:   |:x:              |:x:               |:x:               |:grey_question:   |:grey_question:   |:grey_question:   |:heavy_plus_sign:
 |Zero Size Allocation Special Handling|:heavy_check_mark:|:x:               |:grey_question:   |:grey_question:  |:x:               |:x:               |:x:               |:heavy_check_mark:|:x:               |:x:
 |Read-only global structure           |:heavy_minus_sign:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_check_mark:|:x:               |:x:
-|SW Memory Tagging                    |:heavy_minus_sign:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:heavy_check_mark:|:x:
-|Guarded memcpy/memmove               |:heavy_check_mark:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:heavy_check_mark:
-|Automatic initialization             |:x:               |:heavy_plus_sign: |:x:               |:x:              |:x:               |:x:               |:x:               |:x:               |:x:               |:x:
+|SW Memory Tagging                    |:heavy_minus_sign:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:grey_question:   |:heavy_check_mark:|:x:
+|Guarded memcpy/memmove               |:heavy_check_mark:|:x:               |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_minus_sign:|:x:               |:heavy_check_mark:
+|Automatic initialization             |:x:               |:heavy_plus_sign: |:x:               |:x:              |:x:               |:x:               |:x:               |:heavy_check_mark:|:x:               |:x:
 
 **Lexicon**
 


### PR DESCRIPTION
The only metadata is in a dedicated metadata region with a high entropy random base so verifying adjacent metadata isn't relevant. Question mark seems like the best approach to these points.

Threads are pinned to arenas via round-robin.

Every large allocation has randomly sized guard pages, and large allocations below a certain limit go into a virtual memory quarantine. This isn't sampling, but means it's not relevant to those. For small allocations, there is an equivalent to sampling via the default 50% guard slabs and slot randomization. A random allocation in the slab has a guard slab before it, and a random allocation has a guard slab after it. Both the small and large quarantines are randomized by having both a ring buffer and random swap with a separate array, so allocations can be randomly quarantined for a long time. The intention of these features was not uncovering bugs to be fixed like GWP-ASan, but it does do the same thing.

It provides APIs for dynamic heap overflow checks: one that's fast without any locking, and another using locking to determine whether the slot can be used for use-after-free detection.

Automatic zero initialization is guaranteed by the write-after-free check. It's a feature we provide even though we read rather than write. It would be a performance optimization to write zeroes instead of reads to check for zeroes in some cases, which may be provided as an option, but you still have guaranteed automatic zero init with our existing approach even in the presence of write-after-free bugs. It's either fresh memory or zeroed memory that is checked for zeroes.

SW Memory Tagging is available with it on Android, which is the main platform for it. From our perspective, it's a libc feature. It's not really accurate to say it's not implemented when the main platform we support and the main place it's used (GrapheneOS) has this feature. Our focus will be on actual hardware memory tagging with 4-bit tags with a mix of both randomization and cycling through values based on the generation of the slot, along with making adjacent allocations always have different values to replace canaries.

Even with these changes, our perspective is that the table is very misleading as a whole. The security features listed here are vague and the security properties are not really being compared. What it means to have out-of-band metadata, double-free detection, guard pages, etc. is not defined and what other allocators are doing is not really at all comparable to what hardened_malloc is doing for most of what's listed, with a few exceptions like certain properties of musl malloc.