### PR TITLE
Fix tag refresh

### DIFF
--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -188,10 +188,10 @@ assert(sizeof(size_t) >= 64)
     n &= ~(1UL << k);
 
 #define ALIGN_SZ_UP(n) \
-    ((((n + ALIGNMENT) - 1) >> 3) * ALIGNMENT)
+    ((n + ALIGNMENT - 1) & ~(ALIGNMENT - 1))
 
 #define ALIGN_SZ_DOWN(n) \
-    ((((n + ALIGNMENT) - 1) >> 3) * ALIGNMENT) - ALIGNMENT
+    (((n + ALIGNMENT - 1) & ~(ALIGNMENT - 1)) - ALIGNMENT)
 
 #define ROUND_UP_PAGE(n) \
     ((((n + g_page_size) - 1) >> g_page_size_shift) * (g_page_size))

--- a/src/iso_alloc_mem_tags.c
+++ b/src/iso_alloc_mem_tags.c
@@ -81,7 +81,7 @@ INTERNAL_HIDDEN bool _refresh_zone_mem_tags(iso_alloc_zone_t *zone) {
         uint64_t *_mtp = (zone->user_pages_start - g_page_size - s);
         size_t tms = s / sizeof(uint64_t);
 
-        for(uint64_t o = 0; o > tms; o++) {
+        for(uint64_t o = 0; o < tms; o++) {
             _mtp[o] = us_rand_uint64(&_root->seed);
         }
 


### PR DESCRIPTION
There was a bug in the memory tagging code that resulted in not refresh tags due to the wrong comparison operator in a for loop.

Minor change to align macros.