### PR TITLE
fix overflow check in calloc(), it was using umul instead of mul

### DIFF
--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -1016,8 +1016,8 @@ INTERNAL_HIDDEN ASSUME_ALIGNED void *_iso_calloc(size_t nmemb, size_t size) {
 
     size_t sz = nmemb * size;
 
-    if(UNLIKELY(__builtin_umul_overflow(nmemb, size, &res))) {
-        LOG_AND_ABORT("Call to calloc() will overflow nmemb=%zu size=%zu", nmemb, size);
+    if(sz < size || UNLIKELY(__builtin_mul_overflow(nmemb, size, &res))) {
+        LOG("Call to calloc() will overflow nmemb=%d size=%d = %u", nmemb, size, nmemb * size);
         return NULL;
     }
 

--- a/tests/interfaces_test.c
+++ b/tests/interfaces_test.c
@@ -18,6 +18,13 @@ int main(int argc, char *argv[]) {
         LOG_AND_ABORT("iso_calloc failed")
     }
 
+    p = iso_calloc(INT_MAX-1, 4);
+
+    if(p != NULL) {
+        LOG_AND_ABORT("iso_calloc over check failed")
+    }
+
+
     iso_free(p);
 
     /* Test iso_alloc() */

--- a/tests/interfaces_test.c
+++ b/tests/interfaces_test.c
@@ -18,12 +18,11 @@ int main(int argc, char *argv[]) {
         LOG_AND_ABORT("iso_calloc failed")
     }
 
-    p = iso_calloc(INT_MAX-1, 4);
+    p = iso_calloc(INT_MAX - 1, 4);
 
     if(p != NULL) {
         LOG_AND_ABORT("iso_calloc over check failed")
     }
-
 
     iso_free(p);
 


### PR DESCRIPTION
The calloc multiplication overflow check was using `__builtin_umul_overflow` instead of `__builtin_mul_overflow`.