### PR TITLE
fix a bug that could unmap beyond the bounds of a big zone user page

### DIFF
--- a/include/conf.h
+++ b/include/conf.h
@@ -88,7 +88,7 @@
  * we construct the zone bitmap. You can think of this
  * value as roughly equivalent to M_MMAP_THRESHOLD. Valid
  * values for SMALL_SIZE_MAX are powers of 2 through 131072 */
-#define SMALL_SIZE_MAX 65535
+#define SMALL_SIZE_MAX 65536
 
 /* Big zones are for any allocation bigger than SMALL_SIZE_MAX.
  * We reuse them when possible but not if the reuse would

--- a/tests/alloc_fuzz.c
+++ b/tests/alloc_fuzz.c
@@ -157,7 +157,7 @@ int64_t allocate(size_t array_size, size_t allocation_size) {
     return allocs;
 }
 
-void *start() {
+void *start(void *p) {
     uint64_t total_allocations = 0;
     uint64_t loop = 1;
 


### PR DESCRIPTION
When I introduced used/free lists for big zones I left a code path that would unmap the big zone user pages with the assumption guard pages were always present.