### PR TITLE
improve the management of cached bitmap pages

### DIFF
--- a/include/iso_alloc_ds.h
+++ b/include/iso_alloc_ds.h
@@ -100,21 +100,11 @@ const static int small_bitmap_sizes[] = {
 #endif
 };
 
-#if __APPLE__
-#define BITMAP_BITS 64
-#else
-#define BITMAP_BITS 32
-#endif
-
 /* Preallocated pages for bitmaps are managed using
  * an array of these structures placed in the root */
 typedef struct {
     /* Our bitmap has a bitmap */
-#if __APPLE__
     uint64_t in_use;
-#else
-    uint32_t in_use;
-#endif
     /* Bucket value determines how many times we divy up
      * the bitmap page. eg For BITMAP_SIZE_16 its 256 times */
     uint8_t bucket;

--- a/include/iso_alloc_ds.h
+++ b/include/iso_alloc_ds.h
@@ -85,14 +85,36 @@ typedef struct iso_alloc_big_zone_t {
 
 /* Small bitmap sizes are in reverse order as
  * smaller chunks are more likely to be needed */
-const static uint64_t small_bitmap_sizes[] = {BITMAP_SIZE_1024, BITMAP_SIZE_512, BITMAP_SIZE_256, BITMAP_SIZE_128,
-                                              BITMAP_SIZE_64, BITMAP_SIZE_32, BITMAP_SIZE_16};
+const static int small_bitmap_sizes[] = {
+    BITMAP_SIZE_1024,
+    BITMAP_SIZE_512,
+    BITMAP_SIZE_256,
+    BITMAP_SIZE_128,
+    BITMAP_SIZE_64,
+    BITMAP_SIZE_32,
+/* MacOS targets have 16k page sizes, we would need a
+ * 128-bit bitmap to divide up these pages for zones
+ * holding very large chunks */
+#if !__APPLE__
+    BITMAP_SIZE_16,
+#endif
+};
+
+#if __APPLE__
+#define BITMAP_BITS 64
+#else
+#define BITMAP_BITS 32
+#endif
 
 /* Preallocated pages for bitmaps are managed using
  * an array of these structures placed in the root */
 typedef struct {
     /* Our bitmap has a bitmap */
-    uint16_t in_use;
+#if __APPLE__
+    uint64_t in_use;
+#else
+    uint32_t in_use;
+#endif
     /* Bucket value determines how many times we divy up
      * the bitmap page. eg For BITMAP_SIZE_16 its 256 times */
     uint8_t bucket;

--- a/include/iso_alloc_ds.h
+++ b/include/iso_alloc_ds.h
@@ -92,19 +92,14 @@ const static int small_bitmap_sizes[] = {
     BITMAP_SIZE_128,
     BITMAP_SIZE_64,
     BITMAP_SIZE_32,
-/* MacOS targets have 16k page sizes, we would need a
- * 128-bit bitmap to divide up these pages for zones
- * holding very large chunks */
-#if !__APPLE__
     BITMAP_SIZE_16,
-#endif
 };
 
 /* Preallocated pages for bitmaps are managed using
  * an array of these structures placed in the root */
 typedef struct {
     /* Our bitmap has a bitmap */
-    uint64_t in_use;
+    uint32_t in_use;
     /* Bucket value determines how many times we divy up
      * the bitmap page. eg For BITMAP_SIZE_16 its 256 times */
     uint8_t bucket;

--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -161,8 +161,6 @@ assert(sizeof(size_t) >= 64)
 #define BITS_PER_BYTE 8
 #define BITS_PER_BYTE_SHIFT 3
 
-#define BITS_PER_HALFWORD 16
-
 #define BITS_PER_QWORD 64
 #define BITS_PER_QWORD_SHIFT 6
 

--- a/src/iso_alloc.c
+++ b/src/iso_alloc.c
@@ -510,7 +510,7 @@ INTERNAL_HIDDEN iso_alloc_zone_t *_iso_new_zone(size_t size, bool internal, int3
                     break;
                 }
 
-                for(int z = 0; z < BITMAP_BITS; z++) {
+                for(int z = 0; z < BITS_PER_QWORD; z++) {
                     if((GET_BIT(_root->bitmaps[i].in_use, z)) == 0) {
                         new_zone->bitmap_start = _root->bitmaps[i].bitmap + (new_zone->bitmap_size * z);
                         new_zone->preallocated_bitmap_idx = z;


### PR DESCRIPTION
Minor improvements to the managed of cached bitmap pages. Use a 32 bit bitmap for all platforms. This will likely leave some unused space in a preallocated bitmap page on MacOS where pages are 16k and we want to carve it up for a zone holding large chunks.