### PR TITLE
fix alignment of structures and cached bitmap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,8 @@ ISO_DTOR_CLEANUP = -DISO_DTOR_CLEANUP=0
 SIGNAL_HANDLER = -DSIGNAL_HANDLER=0
 
 ## If you know your target will have an ARMv8.1-A or newer and
-## supports Top Byte Ignore (TBI) then you want to enable this
+## supports Top Byte Ignore (TBI) then you want to enable this.
+## (Currently unused)
 ARM_TBI = 0
 
 ## Enables guard pages around big zone meta data. Big zones


### PR DESCRIPTION
This PR cleans up the alignment of important zone structures and fixes a bug in the cached bitmap implementation discovered as a result.