### PR TITLE
Run the MTE tests in the CI

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -47,6 +47,11 @@ jobs:
       - run: apk update && apk add build-base bash musl-dev linux-headers
       - run: make tests CC=gcc CXX=g++
       - run: make cpp_tests CC=gcc CXX=g++
-
-
-
+  testsuite-mte:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get install clang-12 make qemu qemu-system-arm qemu-user-static
+      - run: sed -i s/-DDISABLE_CANARY=0/-DDISABLE_CANARY=1/ Makefile
+      - run: sed -i s/\#ARM_MTE/ARM_MTE/ Makefile
+      - run: make mte_test


### PR DESCRIPTION
Following the procedure from #217, but it seems that something is wrong, namely `cc1: error: bad value (‘armv8.5-a+memtag’) for ‘-march=’ switch`