### PR TITLE
untag pointers before searching

### DIFF
--- a/src/iso_alloc_mem_tags.c
+++ b/src/iso_alloc_mem_tags.c
@@ -24,7 +24,7 @@ INTERNAL_HIDDEN uint8_t _iso_alloc_get_mem_tag(void *p, iso_alloc_zone_t *zone) 
     }
 
     _mtp += (chunk_offset / zone->chunk_size);
-    ;
+
     return *_mtp;
 #else
     return 0;

--- a/src/iso_alloc_search.c
+++ b/src/iso_alloc_search.c
@@ -11,6 +11,12 @@ INTERNAL_HIDDEN void *_iso_alloc_ptr_search(void *n, bool poison) {
     uint8_t *end = NULL;
     const size_t zones_used = _root->zones_used;
 
+#if MEMORY_TAGGING || (ARM_MTE == 1)
+    /* It should be safe to clear these upper bits even
+     * if the pointer wasn't returned by IsoAlloc. */
+    n = (void *) ((uintptr_t) n & TAGGED_PTR_MASK);
+#endif
+
     for(int32_t i = 0; i < zones_used; i++) {
         iso_alloc_zone_t *zone = &_root->zones[i];
 


### PR DESCRIPTION
Untag pointers before searching a zone for them. This API assumes these pointers were returned by IsoAlloc but should be safe to untag them in any case.