### PR TITLE
Fix compiling error when ARM_MTE=1 iso_alloc_internal.h

### DIFF
--- a/include/iso_alloc_internal.h
+++ b/include/iso_alloc_internal.h
@@ -254,7 +254,7 @@ assert(sizeof(size_t) >= 64)
 #define BIG_ZONE_USER_PAGE_COUNT 2
 #define BIG_ZONE_USER_PAGE_COUNT_SHIFT 1
 
-#if MEMORY_TAGGING
+#if MEMORY_TAGGING || (ARM_MTE == 1)
 #define TAGGED_PTR_MASK 0x00ffffffffffffff
 #define IS_TAGGED_PTR_MASK 0xff00000000000000
 #define UNTAGGED_BITS 56


### PR DESCRIPTION
When ARM_MTE=1, MEMORY_TAGGING has to be 0.  Therefore, the TAGGED_PTR_MAX (used by both) has to be defined if MEMORY_TAGGING is defined or when ARM_MTE is.