### PR TITLE
remove std::thread, use join

### DIFF
--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -122,7 +122,7 @@ int main(int argc, char *argv[]) {
         Derived::operator delete(d, ptr);
     }
 
-#if THREAD_SUPPORT
+#if THREAD_SUPPORT && __linux__
     for(size_t i = 0; i < 4; i++) {
         std::array<std::thread, 4> t;
         for(size_t z = 0; z < 4; z++) {

--- a/tests/thread_tests.c
+++ b/tests/thread_tests.c
@@ -97,6 +97,9 @@ void run_test_threads(void) {
     pthread_create(&t, NULL, allocate, (void *) &ALLOC);
     pthread_create(&tt, NULL, allocate, (void *) &REALLOC);
     pthread_create(&ttt, NULL, allocate, (void *) &CALLOC);
+    pthread_join(t, NULL);
+    pthread_join(tt, NULL);
+    pthread_join(ttt, NULL);
 #endif
 }
 


### PR DESCRIPTION
* Remove `std::thread` from c++ tests for MacOS as it seems to directly be using non-public libsystem_malloc functions and is currently breaking the test
* Join pthreads in C tests